### PR TITLE
docs(README): add link to quick start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 _Note: This is a mono-repo._
 
+## Introduction and Quick Start
+
+See the [Installing Package Manager](https://nrkno.github.io/tv-automation-server-core/docs/getting-started/installation/installing-package-manager) page of the [Sofie System Documentation](https://nrkno.github.io/tv-automation-server-core/) to learn how to get started with Package Manager in a demo environment with CasparCG.
+
 ## File structure
 
 This is a mono-repo, all packages resides in [shared/packages](shared/packages) and [apps/](apps/).


### PR DESCRIPTION
This PR adds links to the Sofie System Documentation, specifically the Quick Start docs for Package Manager.