### PR TITLE
fix: worker child processes exit with null code

### DIFF
--- a/shared/packages/worker/src/worker/accessorHandlers/atem.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/atem.ts
@@ -17,6 +17,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { promisify } from 'util'
 import { UniversalVersion } from '../workers/windowsWorker/lib/lib'
+import { MAX_EXEC_BUFFER } from '../lib/lib'
 
 const fsReadFile = promisify(fs.readFile)
 
@@ -548,26 +549,40 @@ function getStreamIndicies(inputFile: string, type: 'video' | 'audio'): Promise<
 function ffprobe(args: string[]): Promise<string> {
 	return new Promise((resolve, reject) => {
 		const file = process.platform === 'win32' ? 'ffprobe.exe' : 'ffprobe'
-		execFile(file, args, (error, stdout) => {
-			if (error) {
-				reject(error)
-			} else {
-				resolve(stdout)
+		execFile(
+			file,
+			args,
+			{
+				maxBuffer: MAX_EXEC_BUFFER,
+			},
+			(error, stdout) => {
+				if (error) {
+					reject(error)
+				} else {
+					resolve(stdout)
+				}
 			}
-		})
+		)
 	})
 }
 
 function ffmpeg(args: string[]): Promise<string> {
 	return new Promise((resolve, reject) => {
 		const file = process.platform === 'win32' ? 'ffmpeg.exe' : 'ffmpeg'
-		execFile(file, ['-v error', ...args], (error, stdout) => {
-			if (error) {
-				reject(error)
-			} else {
-				resolve(stdout)
+		execFile(
+			file,
+			['-v error', ...args],
+			{
+				maxBuffer: MAX_EXEC_BUFFER,
+			},
+			(error, stdout) => {
+				if (error) {
+					reject(error)
+				} else {
+					resolve(stdout)
+				}
 			}
-		})
+		)
 	})
 }
 

--- a/shared/packages/worker/src/worker/accessorHandlers/fileShare.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/fileShare.ts
@@ -21,6 +21,7 @@ import networkDrive from 'windows-network-drive'
 import { exec } from 'child_process'
 import { FileShareAccessorHandleType, GenericFileAccessorHandle } from './lib/FileHandler'
 import { MonitorInProgress } from '../lib/monitorInProgress'
+import { MAX_EXEC_BUFFER } from '../lib/lib'
 
 const fsStat = promisify(fs.stat)
 const fsAccess = promisify(fs.access)
@@ -444,19 +445,17 @@ export class FileShareAccessorHandle<Metadata> extends GenericFileAccessorHandle
 			}
 			// We're reverting to accessing through the direct path instead
 			if (this.accessor.userName) {
-				const MAX_BUFFER_SIZE = 2000 * 1024
-
 				// Try to add the credentials to the share in Windows:
 				const setupCredentialsCommand = `net use "${folderPath}" /user:${this.accessor.userName} ${this.accessor.password}`
 				try {
-					await pExec(setupCredentialsCommand, { maxBuffer: MAX_BUFFER_SIZE })
+					await pExec(setupCredentialsCommand, { maxBuffer: MAX_EXEC_BUFFER })
 				} catch (err) {
 					if (stringifyError(err, true).match(/multiple connections to a/i)) {
 						// "Multiple connections to a server or shared resource by the same user, using more than one user name, are not allowed. Disconnect all previous connections to the server or shared resource and try again."
 
 						// Remove the old and try again:
 						await pExec(`net use "${folderPath}" /d`)
-						await pExec(setupCredentialsCommand, { maxBuffer: MAX_BUFFER_SIZE })
+						await pExec(setupCredentialsCommand, { maxBuffer: MAX_EXEC_BUFFER })
 					} else {
 						throw err
 					}

--- a/shared/packages/worker/src/worker/lib/lib.ts
+++ b/shared/packages/worker/src/worker/lib/lib.ts
@@ -69,3 +69,5 @@ export interface AccessorWithPackageContainer<T extends PackageContainerOnPackag
 	accessorId: string
 	prio: number
 }
+
+export const MAX_EXEC_BUFFER = 10_486_750

--- a/shared/packages/worker/src/worker/lib/lib.ts
+++ b/shared/packages/worker/src/worker/lib/lib.ts
@@ -70,4 +70,9 @@ export interface AccessorWithPackageContainer<T extends PackageContainerOnPackag
 	prio: number
 }
 
+/**
+ * Maximum buffer when running child_process.execFile. Large spikes of data being sent over STDIO streams can overload
+ * this buffer which will result in the child_process' termination. A large buffer (10M) allows us sufficient time to
+ * process the incoming data.
+ */
 export const MAX_EXEC_BUFFER = 10_486_750

--- a/shared/packages/worker/src/worker/workers/windowsWorker/lib/robocopy.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/lib/robocopy.ts
@@ -51,7 +51,7 @@ export function roboCopyFile(src: string, dst: string, progress?: (progress: num
 			errors.push(data.toString().trim())
 		})
 
-		rbcpy.on('close', (code) => {
+		rbcpy.on('exit', (code) => {
 			rbcpy = undefined
 			if (
 				code === 0 || // No errors occurred, and no copying was done.


### PR DESCRIPTION
This PR replaces some situations where `execFile` is used instead of `spawn`, and the remaining uses of `execFile` are expanded with a sufficiently large buffer.