### PR TITLE
Feat: clean temporary storage

### DIFF
--- a/apps/package-manager/packages/generic/src/generateExpectations/nrk/expectations.ts
+++ b/apps/package-manager/packages/generic/src/generateExpectations/nrk/expectations.ts
@@ -22,8 +22,7 @@ import {
 	generatePackageCopyFileProxy,
 } from './expectations-lib'
 import { getSmartbullExpectedPackages, shouldBeIgnored } from './smartbull'
-
-const TEMPORARY_STORAGE_ID = 'temporary-storage'
+import { TEMPORARY_STORAGE_ID } from './lib'
 
 /** Generate and return the appropriate Expectations based on the provided expectedPackages */
 export function getExpectations(

--- a/apps/package-manager/packages/generic/src/generateExpectations/nrk/lib.ts
+++ b/apps/package-manager/packages/generic/src/generateExpectations/nrk/lib.ts
@@ -1,0 +1,2 @@
+export const SMARTBULL_STORAGE_ID = 'source-smartbull'
+export const TEMPORARY_STORAGE_ID = 'temporary-storage'

--- a/apps/package-manager/packages/generic/src/generateExpectations/nrk/packageContainerExpectations.ts
+++ b/apps/package-manager/packages/generic/src/generateExpectations/nrk/packageContainerExpectations.ts
@@ -1,5 +1,6 @@
 import { ActivePlaylist, PackageContainers } from '../../packageManager'
 import { PackageContainerExpectation } from '@sofie-package-manager/api'
+import { SMARTBULL_STORAGE_ID, TEMPORARY_STORAGE_ID } from './lib'
 
 export function getPackageContainerExpectations(
 	managerId: string,
@@ -29,7 +30,7 @@ export function getPackageContainerExpectations(
 
 		// This is a hard-coded hack for the "smartbull" feature,
 		// to be replaced or moved out later:
-		if (containerId === 'source-smartbull') {
+		if (containerId === SMARTBULL_STORAGE_ID) {
 			o[containerId] = {
 				...packageContainer,
 				id: containerId,
@@ -43,6 +44,22 @@ export function getPackageContainerExpectations(
 						awaitWriteFinishStabilityThreshold: 2000,
 					},
 				},
+			}
+		}
+		// There is a risk that the temporary storage gets a few old files left behind.
+		// Therefore we specifically set the cronjob to remove those:
+		if (containerId === TEMPORARY_STORAGE_ID) {
+			o[containerId] = {
+				...packageContainer,
+				id: containerId,
+				managerId: managerId,
+				cronjobs: {
+					cleanup: {
+						label: 'Clean up old packages and old files',
+						cleanFileAge: 30 * 24 * 3600, // 30 days
+					},
+				},
+				monitors: {},
 			}
 		}
 	}

--- a/apps/package-manager/packages/generic/src/generateExpectations/nrk/smartbull.ts
+++ b/apps/package-manager/packages/generic/src/generateExpectations/nrk/smartbull.ts
@@ -1,6 +1,7 @@
 import { ExpectedPackageWrap } from '../../packageManager'
 import { ExpectedPackage, LoggerInstance } from '@sofie-package-manager/api'
 import { ExpectedPackageWrapMediaFile, PriorityMagnitude } from './types'
+import { SMARTBULL_STORAGE_ID } from './lib'
 
 export function shouldBeIgnored(packageWrap: ExpectedPackageWrap): boolean {
 	// Ignore the original smartbull package:
@@ -17,7 +18,7 @@ export function expectedPackageIsSmartbullSource(packageWrap: ExpectedPackageWra
 
 	if (
 		packageWrap.expectedPackage.type === ExpectedPackage.PackageType.MEDIA_FILE &&
-		packageWrap.sources.find((source) => source.containerId === 'source-smartbull')
+		packageWrap.sources.find((source) => source.containerId === SMARTBULL_STORAGE_ID)
 	) {
 		if ((packageWrap as ExpectedPackageWrapMediaFile).expectedPackage.content.filePath.match(/^smartbull/)) {
 			// the files are on the form "smartbull_TIMESTAMP.mxf/mp4"

--- a/apps/package-manager/packages/generic/src/packageManager.ts
+++ b/apps/package-manager/packages/generic/src/packageManager.ts
@@ -385,17 +385,18 @@ export class PackageManagerHandler {
 					...packageContainer,
 					id: containerId,
 					managerId: this.expectationManager.managerId,
-					cronjobs: {
-						// interval: 0,
-					},
+					cronjobs: {},
 					monitors: {},
 				})
 			}
 			if (isWriteable) {
 				// All writeable packageContainers should have the clean-up cronjob:
-				packageContainerExpectations[containerId].cronjobs.cleanup = {
-					label: 'Clean up old packages',
-				} // Add cronjob to clean up
+				if (!packageContainerExpectations[containerId].cronjobs.cleanup) {
+					// Add cronjob to clean up:
+					packageContainerExpectations[containerId].cronjobs.cleanup = {
+						label: 'Clean up old packages',
+					}
+				}
 			}
 		}
 	}

--- a/shared/packages/api/src/packageContainerApi.ts
+++ b/shared/packages/api/src/packageContainerApi.ts
@@ -16,6 +16,8 @@ export interface PackageContainerExpectation extends PackageContainer {
 		interval?: number
 		cleanup?: {
 			label: string
+			/** If set, untracked files will also be removed after this time (in seconds) */
+			cleanFileAge?: number
 		}
 	}
 	/** Defines which monitors are expected to run */

--- a/shared/packages/expectationManager/src/expectationManager.ts
+++ b/shared/packages/expectationManager/src/expectationManager.ts
@@ -1891,21 +1891,28 @@ export class ExpectationManager extends HelpfulEventEmitter {
 						}
 					}
 
-					const cronJobStatus = await workerAgent.api.runPackageContainerCronJob(
-						trackedPackageContainer.packageContainer
-					)
-					if (!cronJobStatus.success) {
-						badStatus = true
-						this.logger.verbose(
-							`ExpectationManager._evaluateAllTrackedPackageContainers: runPackageContainerCronJob did not suceed: ${JSON.stringify(
-								cronJobStatus.reason
-							)}`
+					const cronjobInterval =
+						trackedPackageContainer.packageContainer.cronjobs.interval ||
+						this.constants.DEFAULT_CRONJOB_INTERVAL
+					const timeSinceLastCronjob = Date.now() - trackedPackageContainer.lastCronjobTime
+					if (timeSinceLastCronjob > cronjobInterval) {
+						trackedPackageContainer.lastCronjobTime = Date.now()
+						const cronJobStatus = await workerAgent.api.runPackageContainerCronJob(
+							trackedPackageContainer.packageContainer
 						)
-						this.updateTrackedPackageContainerStatus(trackedPackageContainer, StatusCode.BAD, {
-							user: 'Cron job not completed, due to: ' + cronJobStatus.reason.user,
-							tech: 'Cron job not completed, due to: ' + cronJobStatus.reason.tech,
-						})
-						continue
+						if (!cronJobStatus.success) {
+							badStatus = true
+							this.logger.error(
+								`ExpectationManager._evaluateAllTrackedPackageContainers: runPackageContainerCronJob did not suceed: ${JSON.stringify(
+									cronJobStatus.reason
+								)}`
+							)
+							this.updateTrackedPackageContainerStatus(trackedPackageContainer, StatusCode.BAD, {
+								user: 'Cron job not completed, due to: ' + cronJobStatus.reason.user,
+								tech: 'Cron job not completed, due to: ' + cronJobStatus.reason.tech,
+							})
+							continue
+						}
 					}
 				}
 
@@ -2271,6 +2278,9 @@ interface TrackedPackageContainerExpectation {
 
 	/** Timestamp of the last time the expectation was evaluated. */
 	lastEvaluationTime: number
+
+	/** Timestamp of the last time the cronjob was run */
+	lastCronjobTime: number
 
 	/** If the monitor is set up okay */
 	monitorIsSetup: boolean

--- a/shared/packages/expectationManager/src/expectationManager.ts
+++ b/shared/packages/expectationManager/src/expectationManager.ts
@@ -1673,6 +1673,7 @@ export class ExpectationManager extends HelpfulEventEmitter {
 					isUpdated: true,
 					removed: false,
 					lastEvaluationTime: 0,
+					lastCronjobTime: 0,
 					monitorIsSetup: false,
 					status: {
 						status: StatusCode.UNKNOWN,

--- a/shared/packages/expectationManager/src/lib/constants.ts
+++ b/shared/packages/expectationManager/src/lib/constants.ts
@@ -25,6 +25,9 @@ export interface ExpectationManagerConstants {
 
 	/** How many times to try to remove a package upon fail */
 	FAILED_REMOVE_COUNT: number
+
+	/** Default interval for running cronjobs */
+	DEFAULT_CRONJOB_INTERVAL: number
 }
 
 export function getDefaultConstants(): ExpectationManagerConstants {
@@ -40,5 +43,6 @@ export function getDefaultConstants(): ExpectationManagerConstants {
 		ERROR_WAIT_TIME: 30 * 1000,
 
 		FAILED_REMOVE_COUNT: 2,
+		DEFAULT_CRONJOB_INTERVAL: 60 * 1000,
 	}
 }

--- a/shared/packages/worker/src/worker/accessorHandlers/fileShare.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/fileShare.ts
@@ -327,7 +327,10 @@ export class FileShareAccessorHandle<Metadata> extends GenericFileAccessorHandle
 			if (cronjob === 'interval') {
 				// ignore
 			} else if (cronjob === 'cleanup') {
+				const options = packageContainerExp.cronjobs[cronjob]
+
 				badReason = await this.removeDuePackages()
+				if (!badReason && options?.cleanFileAge) badReason = await this.cleanupOldFiles(options.cleanFileAge)
 			} else {
 				// Assert that cronjob is of type "never", to ensure that all types of cronjobs are handled:
 				assertNever(cronjob)

--- a/shared/packages/worker/src/worker/accessorHandlers/http.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/http.ts
@@ -155,6 +155,11 @@ export class HTTPAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 				// ignore
 			} else if (cronjob === 'cleanup') {
 				badReason = await this.removeDuePackages()
+				const options = packageContainerExp.cronjobs[cronjob]
+				badReason = await this.removeDuePackages()
+				if (!badReason && options?.cleanFileAge) {
+					// Not supported, since we aren't able to properly list all untracked files on a generic http-server
+				}
 			} else {
 				// Assert that cronjob is of type "never", to ensure that all types of cronjobs are handled:
 				assertNever(cronjob)

--- a/shared/packages/worker/src/worker/accessorHandlers/httpProxy.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/httpProxy.ts
@@ -181,7 +181,11 @@ export class HTTPProxyAccessorHandle<Metadata> extends GenericAccessorHandle<Met
 			if (cronjob === 'interval') {
 				// ignore
 			} else if (cronjob === 'cleanup') {
+				const options = packageContainerExp.cronjobs[cronjob]
 				badReason = await this.removeDuePackages()
+				if (!badReason && options?.cleanFileAge) {
+					// Not supported, however the http-server has its own cleanup routine
+				}
 			} else {
 				// Assert that cronjob is of type "never", to ensure that all types of cronjobs are handled:
 				assertNever(cronjob)

--- a/shared/packages/worker/src/worker/accessorHandlers/localFolder.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/localFolder.ts
@@ -264,7 +264,10 @@ export class LocalFolderAccessorHandle<Metadata> extends GenericFileAccessorHand
 			if (cronjob === 'interval') {
 				// ignore
 			} else if (cronjob === 'cleanup') {
+				const options = packageContainerExp.cronjobs[cronjob]
+
 				badReason = await this.removeDuePackages()
+				if (!badReason && options?.cleanFileAge) badReason = await this.cleanupOldFiles(options.cleanFileAge)
 			} else {
 				// Assert that cronjob is of type "never", to ensure that all types of cronjobs are handled:
 				assertNever(cronjob)


### PR DESCRIPTION
This PR adds a feature to the Package Container cleanup-cronjob, the `cleanFileAge`. When set, any file older than a certain time will be removed from the PackageContainer.

This is useful for certain types of PackageContainers where we want to clean up old files after ourselves, like for a temporary storage.