### PR TITLE
fix: accept apiKeyRead and apiKeyWrite for HEAD requests as well

### DIFF
--- a/apps/http-server/packages/generic/src/server.ts
+++ b/apps/http-server/packages/generic/src/server.ts
@@ -63,7 +63,7 @@ export class PackageProxyServer {
 				ctx.request.query?.apiKey || // Querystring parameter
 				ctx.request.body?.apiKey // Body parameter
 
-			if (ctx.request.method === 'GET') {
+			if (ctx.request.method === 'GET' || ctx.request.method === 'HEAD') {
 				if (
 					// Both read and write keys are accepted for GET requests
 					!this.config.httpServer.apiKeyRead ||


### PR DESCRIPTION
The HTTP server should accept both keys for HEAD requests as well