### PR TITLE
fix: use a shorter time-span for black frame detection

### DIFF
--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/lib/scan.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/lib/scan.ts
@@ -231,7 +231,7 @@ export function scanMoreInfo(
 				targetVersion.blackDuration = targetVersion.blackDuration.slice(0, -1)
 			}
 			filterString +=
-				`blackdetect=d=${targetVersion.blackDuration || '2.0'}:` +
+				`blackdetect=d=${targetVersion.blackDuration || '0.2'}:` +
 				`pic_th=${targetVersion.blackRatio || 0.98}:` +
 				`pix_th=${targetVersion.blackThreshold || 0.1}`
 		}


### PR DESCRIPTION
We have feedback that the default 2s black frame detection threshold is impractical. Proposing a more practical, 200ms.