### PR TITLE
fix: blackDetectRegex expects black_duration to be a number with a decimal point

### DIFF
--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/lib/scan.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/lib/scan.ts
@@ -322,7 +322,7 @@ export function scanMoreInfo(
 				const durationRegex = /Duration:\s?(\d+):(\d+):([\d.]+)/
 				const sceneRegex = /Parsed_showinfo_(.*)pts_time:([\d.]+)\s+/g
 				const blackDetectRegex =
-					/(black_start:)(\d+(.\d+)?)( black_end:)(\d+(.\d+)?)( black_duration:)(\d+(.\d+))?/g
+					/(black_start:)(\d+(.\d+)?)( black_end:)(\d+(.\d+)?)( black_duration:)(\d+(.\d+)?)/g
 				const freezeDetectStart = /(lavfi\.freezedetect\.freeze_start: )(\d+(.\d+)?)/g
 				const freezeDetectDuration = /(lavfi\.freezedetect\.freeze_duration: )(\d+(.\d+)?)/g
 				const freezeDetectEnd = /(lavfi\.freezedetect\.freeze_end: )(\d+(.\d+)?)/g


### PR DESCRIPTION
This PR fixes an issue where the blackDetectRegex doesn't properly match if the black_duration is an integer without a decimal part.