### PR TITLE
fix: update server-core-integration

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: ['14', '16', '18']
+        node_version: ['14', '16']
         os: [ubuntu-latest] # [windows-latest, macOS-latest]
     timeout-minutes: 10
     steps:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+package.json

--- a/apps/_boilerplate/app/package.json
+++ b/apps/_boilerplate/app/package.json
@@ -1,36 +1,34 @@
 {
-    "name": "@boilerplate/app",
-    "version": "1.39.0",
-    "description": "Boilerplace",
-    "private": true,
-    "scripts": {
-        "build": "rimraf dist && yarn build:main",
-        "build:main": "tsc -p tsconfig.json",
-        "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js boilerplate.exe && node ../../../scripts/copy-natives.js win32-x64",
-        "__test": "jest",
-        "start": "node dist/index.js",
-        "precommit": "lint-staged"
-    },
-    "devDependencies": {
-        "lint-staged": "^7.2.0",
-        "nexe": "^3.3.7"
-    },
-    "dependencies": {
-        "@boilerplate/generic": "1.39.0"
-    },
-    "peerDependencies": {
-        "@sofie-automation/blueprints-integration": "*"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "engines": {
-        "node": ">=14.18.0"
-    },
-    "lint-staged": {
-        "*.{js,css,json,md,scss}": [
-            "prettier"
-        ],
-        "*.{ts,tsx}": [
-            "eslint"
-        ]
-    }
+	"name": "@boilerplate/app",
+	"version": "1.39.0",
+	"description": "Boilerplace",
+	"private": true,
+	"scripts": {
+		"build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.json",
+		"build-win32": "mkdir deploy & node ../../../scripts/build-win32.js boilerplate.exe && node ../../../scripts/copy-natives.js win32-x64",
+		"__test": "jest",
+		"start": "node dist/index.js",
+		"precommit": "lint-staged"
+	},
+	"devDependencies": {
+		"lint-staged": "^7.2.0",
+		"nexe": "^3.3.7"
+	},
+	"dependencies": {
+		"@boilerplate/generic": "1.39.0"
+	},
+	"peerDependencies": {},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier"
+		],
+		"*.{ts,tsx}": [
+			"eslint"
+		]
+	}
 }

--- a/apps/_boilerplate/app/package.json
+++ b/apps/_boilerplate/app/package.json
@@ -1,34 +1,34 @@
 {
-	"name": "@boilerplate/app",
-	"version": "1.39.0",
-	"description": "Boilerplace",
-	"private": true,
-	"scripts": {
-		"build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"build-win32": "mkdir deploy & node ../../../scripts/build-win32.js boilerplate.exe && node ../../../scripts/copy-natives.js win32-x64",
-		"__test": "jest",
-		"start": "node dist/index.js",
-		"precommit": "lint-staged"
-	},
-	"devDependencies": {
-		"lint-staged": "^7.2.0",
-		"nexe": "^3.3.7"
-	},
-	"dependencies": {
-		"@boilerplate/generic": "1.39.0"
-	},
-	"peerDependencies": {},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@boilerplate/app",
+  "version": "1.39.0",
+  "description": "Boilerplace",
+  "private": true,
+  "scripts": {
+    "build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js boilerplate.exe && node ../../../scripts/copy-natives.js win32-x64",
+    "__test": "jest",
+    "start": "node dist/index.js",
+    "precommit": "lint-staged"
+  },
+  "devDependencies": {
+    "lint-staged": "^7.2.0",
+    "nexe": "^3.3.7"
+  },
+  "dependencies": {
+    "@boilerplate/generic": "1.39.0"
+  },
+  "peerDependencies": {},
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/apps/_boilerplate/app/package.json
+++ b/apps/_boilerplate/app/package.json
@@ -1,34 +1,34 @@
 {
-  "name": "@boilerplate/app",
-  "version": "1.39.0",
-  "description": "Boilerplace",
-  "private": true,
-  "scripts": {
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js boilerplate.exe && node ../../../scripts/copy-natives.js win32-x64",
-    "__test": "jest",
-    "start": "node dist/index.js",
-    "precommit": "lint-staged"
-  },
-  "devDependencies": {
-    "lint-staged": "^7.2.0",
-    "nexe": "^3.3.7"
-  },
-  "dependencies": {
-    "@boilerplate/generic": "1.39.0"
-  },
-  "peerDependencies": {},
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
-    ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "name": "@boilerplate/app",
+    "version": "1.39.0",
+    "description": "Boilerplace",
+    "private": true,
+    "scripts": {
+        "build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js boilerplate.exe && node ../../../scripts/copy-natives.js win32-x64",
+        "__test": "jest",
+        "start": "node dist/index.js",
+        "precommit": "lint-staged"
+    },
+    "devDependencies": {
+        "lint-staged": "^7.2.0",
+        "nexe": "^3.3.7"
+    },
+    "dependencies": {
+        "@boilerplate/generic": "1.39.0"
+    },
+    "peerDependencies": {},
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/apps/_boilerplate/packages/generic/package.json
+++ b/apps/_boilerplate/packages/generic/package.json
@@ -1,29 +1,29 @@
 {
-	"name": "@boilerplate/generic",
-	"version": "1.39.0",
-	"private": true,
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"scripts": {
-		"build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"__test": "jest",
-		"precommit": "lint-staged"
-	},
-	"peerDependencies": {},
-	"devDependencies": {
-		"lint-staged": "^7.2.0"
-	},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@boilerplate/generic",
+  "version": "1.39.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "__test": "jest",
+    "precommit": "lint-staged"
+  },
+  "peerDependencies": {},
+  "devDependencies": {
+    "lint-staged": "^7.2.0"
+  },
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/apps/_boilerplate/packages/generic/package.json
+++ b/apps/_boilerplate/packages/generic/package.json
@@ -1,29 +1,29 @@
 {
-  "name": "@boilerplate/generic",
-  "version": "1.39.0",
-  "private": true,
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "__test": "jest",
-    "precommit": "lint-staged"
-  },
-  "peerDependencies": {},
-  "devDependencies": {
-    "lint-staged": "^7.2.0"
-  },
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
-    ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "name": "@boilerplate/generic",
+    "version": "1.39.0",
+    "private": true,
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "scripts": {
+        "build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "__test": "jest",
+        "precommit": "lint-staged"
+    },
+    "peerDependencies": {},
+    "devDependencies": {
+        "lint-staged": "^7.2.0"
+    },
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/apps/_boilerplate/packages/generic/package.json
+++ b/apps/_boilerplate/packages/generic/package.json
@@ -1,31 +1,29 @@
 {
-    "name": "@boilerplate/generic",
-    "version": "1.39.0",
-    "private": true,
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "scripts": {
-        "build": "rimraf dist && yarn build:main",
-        "build:main": "tsc -p tsconfig.json",
-        "__test": "jest",
-        "precommit": "lint-staged"
-    },
-    "peerDependencies": {
-        "@sofie-automation/blueprints-integration": "*"
-    },
-    "devDependencies": {
-        "lint-staged": "^7.2.0"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "engines": {
-        "node": ">=14.18.0"
-    },
-    "lint-staged": {
-        "*.{js,css,json,md,scss}": [
-            "prettier"
-        ],
-        "*.{ts,tsx}": [
-            "eslint"
-        ]
-    }
+	"name": "@boilerplate/generic",
+	"version": "1.39.0",
+	"private": true,
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"scripts": {
+		"build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.json",
+		"__test": "jest",
+		"precommit": "lint-staged"
+	},
+	"peerDependencies": {},
+	"devDependencies": {
+		"lint-staged": "^7.2.0"
+	},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier"
+		],
+		"*.{ts,tsx}": [
+			"eslint"
+		]
+	}
 }

--- a/apps/appcontainer-node/app/package.json
+++ b/apps/appcontainer-node/app/package.json
@@ -1,34 +1,34 @@
 {
-	"name": "@appcontainer-node/app",
-	"version": "1.39.7",
-	"description": "AppContainer-Node.js",
-	"private": true,
-	"scripts": {
-		"build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"build-win32": "mkdir deploy & node ../../../scripts/build-win32.js appContainer-node.exe && node ../../../scripts/copy-natives.js win32-x64",
-		"__test": "jest",
-		"start": "node dist/index.js",
-		"precommit": "lint-staged"
-	},
-	"devDependencies": {
-		"lint-staged": "^7.2.0",
-		"nexe": "^3.3.7"
-	},
-	"dependencies": {
-		"@appcontainer-node/generic": "1.39.7"
-	},
-	"peerDependencies": {},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@appcontainer-node/app",
+  "version": "1.39.7",
+  "description": "AppContainer-Node.js",
+  "private": true,
+  "scripts": {
+    "build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js appContainer-node.exe && node ../../../scripts/copy-natives.js win32-x64",
+    "__test": "jest",
+    "start": "node dist/index.js",
+    "precommit": "lint-staged"
+  },
+  "devDependencies": {
+    "lint-staged": "^7.2.0",
+    "nexe": "^3.3.7"
+  },
+  "dependencies": {
+    "@appcontainer-node/generic": "1.39.7"
+  },
+  "peerDependencies": {},
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/apps/appcontainer-node/app/package.json
+++ b/apps/appcontainer-node/app/package.json
@@ -1,34 +1,34 @@
 {
-  "name": "@appcontainer-node/app",
-  "version": "1.39.7",
-  "description": "AppContainer-Node.js",
-  "private": true,
-  "scripts": {
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js appContainer-node.exe && node ../../../scripts/copy-natives.js win32-x64",
-    "__test": "jest",
-    "start": "node dist/index.js",
-    "precommit": "lint-staged"
-  },
-  "devDependencies": {
-    "lint-staged": "^7.2.0",
-    "nexe": "^3.3.7"
-  },
-  "dependencies": {
-    "@appcontainer-node/generic": "1.39.7"
-  },
-  "peerDependencies": {},
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
-    ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "name": "@appcontainer-node/app",
+    "version": "1.39.7",
+    "description": "AppContainer-Node.js",
+    "private": true,
+    "scripts": {
+        "build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js appContainer-node.exe && node ../../../scripts/copy-natives.js win32-x64",
+        "__test": "jest",
+        "start": "node dist/index.js",
+        "precommit": "lint-staged"
+    },
+    "devDependencies": {
+        "lint-staged": "^7.2.0",
+        "nexe": "^3.3.7"
+    },
+    "dependencies": {
+        "@appcontainer-node/generic": "1.39.7"
+    },
+    "peerDependencies": {},
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/apps/appcontainer-node/app/package.json
+++ b/apps/appcontainer-node/app/package.json
@@ -1,36 +1,34 @@
 {
-    "name": "@appcontainer-node/app",
-    "version": "1.39.7",
-    "description": "AppContainer-Node.js",
-    "private": true,
-    "scripts": {
-        "build": "rimraf dist && yarn build:main",
-        "build:main": "tsc -p tsconfig.json",
-        "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js appContainer-node.exe && node ../../../scripts/copy-natives.js win32-x64",
-        "__test": "jest",
-        "start": "node dist/index.js",
-        "precommit": "lint-staged"
-    },
-    "devDependencies": {
-        "lint-staged": "^7.2.0",
-        "nexe": "^3.3.7"
-    },
-    "dependencies": {
-        "@appcontainer-node/generic": "1.39.7"
-    },
-    "peerDependencies": {
-        "@sofie-automation/blueprints-integration": "*"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "engines": {
-        "node": ">=14.18.0"
-    },
-    "lint-staged": {
-        "*.{js,css,json,md,scss}": [
-            "prettier"
-        ],
-        "*.{ts,tsx}": [
-            "eslint"
-        ]
-    }
+	"name": "@appcontainer-node/app",
+	"version": "1.39.7",
+	"description": "AppContainer-Node.js",
+	"private": true,
+	"scripts": {
+		"build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.json",
+		"build-win32": "mkdir deploy & node ../../../scripts/build-win32.js appContainer-node.exe && node ../../../scripts/copy-natives.js win32-x64",
+		"__test": "jest",
+		"start": "node dist/index.js",
+		"precommit": "lint-staged"
+	},
+	"devDependencies": {
+		"lint-staged": "^7.2.0",
+		"nexe": "^3.3.7"
+	},
+	"dependencies": {
+		"@appcontainer-node/generic": "1.39.7"
+	},
+	"peerDependencies": {},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier"
+		],
+		"*.{ts,tsx}": [
+			"eslint"
+		]
+	}
 }

--- a/apps/appcontainer-node/packages/generic/package.json
+++ b/apps/appcontainer-node/packages/generic/package.json
@@ -1,37 +1,35 @@
 {
-    "name": "@appcontainer-node/generic",
-    "version": "1.39.7",
-    "private": true,
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "scripts": {
-        "build": "rimraf dist && yarn build:main",
-        "build:main": "tsc -p tsconfig.json",
-        "__test": "jest",
-        "precommit": "lint-staged"
-    },
-    "peerDependencies": {
-        "@sofie-automation/blueprints-integration": "*"
-    },
-    "dependencies": {
-        "@sofie-package-manager/api": "1.39.2",
-        "@sofie-package-manager/worker": "1.39.7",
-        "underscore": "^1.12.0"
-    },
-    "devDependencies": {
-        "@types/underscore": "^1.10.24",
-        "lint-staged": "^7.2.0"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "engines": {
-        "node": ">=14.18.0"
-    },
-    "lint-staged": {
-        "*.{js,css,json,md,scss}": [
-            "prettier"
-        ],
-        "*.{ts,tsx}": [
-            "eslint"
-        ]
-    }
+	"name": "@appcontainer-node/generic",
+	"version": "1.39.7",
+	"private": true,
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"scripts": {
+		"build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.json",
+		"__test": "jest",
+		"precommit": "lint-staged"
+	},
+	"peerDependencies": {},
+	"dependencies": {
+		"@sofie-package-manager/api": "1.39.2",
+		"@sofie-package-manager/worker": "1.39.7",
+		"underscore": "^1.12.0"
+	},
+	"devDependencies": {
+		"@types/underscore": "^1.10.24",
+		"lint-staged": "^7.2.0"
+	},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier"
+		],
+		"*.{ts,tsx}": [
+			"eslint"
+		]
+	}
 }

--- a/apps/appcontainer-node/packages/generic/package.json
+++ b/apps/appcontainer-node/packages/generic/package.json
@@ -1,35 +1,35 @@
 {
-  "name": "@appcontainer-node/generic",
-  "version": "1.39.7",
-  "private": true,
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "__test": "jest",
-    "precommit": "lint-staged"
-  },
-  "peerDependencies": {},
-  "dependencies": {
-    "@sofie-package-manager/api": "1.39.2",
-    "@sofie-package-manager/worker": "1.39.7",
-    "underscore": "^1.12.0"
-  },
-  "devDependencies": {
-    "@types/underscore": "^1.10.24",
-    "lint-staged": "^7.2.0"
-  },
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
-    ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "name": "@appcontainer-node/generic",
+    "version": "1.39.7",
+    "private": true,
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "scripts": {
+        "build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "__test": "jest",
+        "precommit": "lint-staged"
+    },
+    "peerDependencies": {},
+    "dependencies": {
+        "@sofie-package-manager/api": "1.39.2",
+        "@sofie-package-manager/worker": "1.39.7",
+        "underscore": "^1.12.0"
+    },
+    "devDependencies": {
+        "@types/underscore": "^1.10.24",
+        "lint-staged": "^7.2.0"
+    },
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/apps/appcontainer-node/packages/generic/package.json
+++ b/apps/appcontainer-node/packages/generic/package.json
@@ -1,35 +1,35 @@
 {
-	"name": "@appcontainer-node/generic",
-	"version": "1.39.7",
-	"private": true,
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"scripts": {
-		"build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"__test": "jest",
-		"precommit": "lint-staged"
-	},
-	"peerDependencies": {},
-	"dependencies": {
-		"@sofie-package-manager/api": "1.39.2",
-		"@sofie-package-manager/worker": "1.39.7",
-		"underscore": "^1.12.0"
-	},
-	"devDependencies": {
-		"@types/underscore": "^1.10.24",
-		"lint-staged": "^7.2.0"
-	},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@appcontainer-node/generic",
+  "version": "1.39.7",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "__test": "jest",
+    "precommit": "lint-staged"
+  },
+  "peerDependencies": {},
+  "dependencies": {
+    "@sofie-package-manager/api": "1.39.2",
+    "@sofie-package-manager/worker": "1.39.7",
+    "underscore": "^1.12.0"
+  },
+  "devDependencies": {
+    "@types/underscore": "^1.10.24",
+    "lint-staged": "^7.2.0"
+  },
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/apps/http-server/app/package.json
+++ b/apps/http-server/app/package.json
@@ -1,34 +1,34 @@
 {
-  "name": "@http-server/app",
-  "version": "1.39.2",
-  "description": "Upload to and serve proxies of packages",
-  "private": true,
-  "scripts": {
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js http-server.exe && node ../../../scripts/copy-natives.js win32-x64",
-    "__test": "jest",
-    "start": "node dist/index.js",
-    "precommit": "lint-staged"
-  },
-  "devDependencies": {
-    "lint-staged": "^7.2.0",
-    "nexe": "^3.3.7"
-  },
-  "dependencies": {
-    "@http-server/generic": "1.39.2"
-  },
-  "peerDependencies": {},
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
-    ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "name": "@http-server/app",
+    "version": "1.39.2",
+    "description": "Upload to and serve proxies of packages",
+    "private": true,
+    "scripts": {
+        "build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js http-server.exe && node ../../../scripts/copy-natives.js win32-x64",
+        "__test": "jest",
+        "start": "node dist/index.js",
+        "precommit": "lint-staged"
+    },
+    "devDependencies": {
+        "lint-staged": "^7.2.0",
+        "nexe": "^3.3.7"
+    },
+    "dependencies": {
+        "@http-server/generic": "1.39.2"
+    },
+    "peerDependencies": {},
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/apps/http-server/app/package.json
+++ b/apps/http-server/app/package.json
@@ -1,34 +1,34 @@
 {
-	"name": "@http-server/app",
-	"version": "1.39.2",
-	"description": "Upload to and serve proxies of packages",
-	"private": true,
-	"scripts": {
-		"build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"build-win32": "mkdir deploy & node ../../../scripts/build-win32.js http-server.exe && node ../../../scripts/copy-natives.js win32-x64",
-		"__test": "jest",
-		"start": "node dist/index.js",
-		"precommit": "lint-staged"
-	},
-	"devDependencies": {
-		"lint-staged": "^7.2.0",
-		"nexe": "^3.3.7"
-	},
-	"dependencies": {
-		"@http-server/generic": "1.39.2"
-	},
-	"peerDependencies": {},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@http-server/app",
+  "version": "1.39.2",
+  "description": "Upload to and serve proxies of packages",
+  "private": true,
+  "scripts": {
+    "build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js http-server.exe && node ../../../scripts/copy-natives.js win32-x64",
+    "__test": "jest",
+    "start": "node dist/index.js",
+    "precommit": "lint-staged"
+  },
+  "devDependencies": {
+    "lint-staged": "^7.2.0",
+    "nexe": "^3.3.7"
+  },
+  "dependencies": {
+    "@http-server/generic": "1.39.2"
+  },
+  "peerDependencies": {},
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/apps/http-server/app/package.json
+++ b/apps/http-server/app/package.json
@@ -1,36 +1,34 @@
 {
-    "name": "@http-server/app",
-    "version": "1.39.2",
-    "description": "Upload to and serve proxies of packages",
-    "private": true,
-    "scripts": {
-        "build": "rimraf dist && yarn build:main",
-        "build:main": "tsc -p tsconfig.json",
-        "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js http-server.exe && node ../../../scripts/copy-natives.js win32-x64",
-        "__test": "jest",
-        "start": "node dist/index.js",
-        "precommit": "lint-staged"
-    },
-    "devDependencies": {
-        "lint-staged": "^7.2.0",
-        "nexe": "^3.3.7"
-    },
-    "dependencies": {
-        "@http-server/generic": "1.39.2"
-    },
-    "peerDependencies": {
-        "@sofie-automation/blueprints-integration": "*"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "engines": {
-        "node": ">=14.18.0"
-    },
-    "lint-staged": {
-        "*.{js,css,json,md,scss}": [
-            "prettier"
-        ],
-        "*.{ts,tsx}": [
-            "eslint"
-        ]
-    }
+	"name": "@http-server/app",
+	"version": "1.39.2",
+	"description": "Upload to and serve proxies of packages",
+	"private": true,
+	"scripts": {
+		"build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.json",
+		"build-win32": "mkdir deploy & node ../../../scripts/build-win32.js http-server.exe && node ../../../scripts/copy-natives.js win32-x64",
+		"__test": "jest",
+		"start": "node dist/index.js",
+		"precommit": "lint-staged"
+	},
+	"devDependencies": {
+		"lint-staged": "^7.2.0",
+		"nexe": "^3.3.7"
+	},
+	"dependencies": {
+		"@http-server/generic": "1.39.2"
+	},
+	"peerDependencies": {},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier"
+		],
+		"*.{ts,tsx}": [
+			"eslint"
+		]
+	}
 }

--- a/apps/http-server/packages/generic/package.json
+++ b/apps/http-server/packages/generic/package.json
@@ -1,59 +1,59 @@
 {
-  "name": "@http-server/generic",
-  "version": "1.39.2",
-  "private": true,
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "__test": "jest",
-    "precommit": "lint-staged"
-  },
-  "peerDependencies": {},
-  "dependencies": {
-    "@koa/cors": "^3.0.0",
-    "@koa/multer": "3.0.0",
-    "@sofie-package-manager/api": "1.39.2",
-    "koa": "^2.11.0",
-    "koa-bodyparser": "^4.3.0",
-    "koa-range": "^0.3.0",
-    "koa-router": "^8.0.8",
-    "mime-types": "^2.1.28",
-    "mkdirp": "^1.0.4",
-    "multer": "2.0.0-rc.2",
-    "pretty-bytes": "^5.5.0",
-    "tslib": "^2.1.0",
-    "underscore": "^1.12.0",
-    "yargs": "^16.2.0"
-  },
-  "devDependencies": {
-    "@sofie-automation/code-standard-preset": "^0.2.1",
-    "@types/jest": "^26.0.19",
-    "@types/koa": "^2.11.6",
-    "@types/koa-bodyparser": "^4.3.0",
-    "@types/koa-range": "^0.3.2",
-    "@types/koa-router": "^7.4.0",
-    "@types/koa__cors": "^3.0.2",
-    "@types/koa__multer": "^2.0.2",
-    "@types/mime-types": "^2.1.0",
-    "@types/mkdirp": "^1.0.1",
-    "@types/node": "^14.14.31",
-    "@types/underscore": "^1.10.24",
-    "@types/yargs": "^15.0.12",
-    "lint-staged": "^7.2.0",
-    "nexe": "^3.3.7"
-  },
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
-    ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "name": "@http-server/generic",
+    "version": "1.39.2",
+    "private": true,
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "scripts": {
+        "build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "__test": "jest",
+        "precommit": "lint-staged"
+    },
+    "peerDependencies": {},
+    "dependencies": {
+        "@koa/cors": "^3.0.0",
+        "@koa/multer": "3.0.0",
+        "@sofie-package-manager/api": "1.39.2",
+        "koa": "^2.11.0",
+        "koa-bodyparser": "^4.3.0",
+        "koa-range": "^0.3.0",
+        "koa-router": "^8.0.8",
+        "mime-types": "^2.1.28",
+        "mkdirp": "^1.0.4",
+        "multer": "2.0.0-rc.2",
+        "pretty-bytes": "^5.5.0",
+        "tslib": "^2.1.0",
+        "underscore": "^1.12.0",
+        "yargs": "^16.2.0"
+    },
+    "devDependencies": {
+        "@sofie-automation/code-standard-preset": "^0.2.1",
+        "@types/jest": "^26.0.19",
+        "@types/koa": "^2.11.6",
+        "@types/koa-bodyparser": "^4.3.0",
+        "@types/koa-range": "^0.3.2",
+        "@types/koa-router": "^7.4.0",
+        "@types/koa__cors": "^3.0.2",
+        "@types/koa__multer": "^2.0.2",
+        "@types/mime-types": "^2.1.0",
+        "@types/mkdirp": "^1.0.1",
+        "@types/node": "^14.14.31",
+        "@types/underscore": "^1.10.24",
+        "@types/yargs": "^15.0.12",
+        "lint-staged": "^7.2.0",
+        "nexe": "^3.3.7"
+    },
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/apps/http-server/packages/generic/package.json
+++ b/apps/http-server/packages/generic/package.json
@@ -1,61 +1,59 @@
 {
-    "name": "@http-server/generic",
-    "version": "1.39.2",
-    "private": true,
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "scripts": {
-        "build": "rimraf dist && yarn build:main",
-        "build:main": "tsc -p tsconfig.json",
-        "__test": "jest",
-        "precommit": "lint-staged"
-    },
-    "peerDependencies": {
-        "@sofie-automation/blueprints-integration": "*"
-    },
-    "dependencies": {
-        "@koa/cors": "^3.0.0",
-        "@koa/multer": "3.0.0",
-        "@sofie-package-manager/api": "1.39.2",
-        "koa": "^2.11.0",
-        "koa-bodyparser": "^4.3.0",
-        "koa-range": "^0.3.0",
-        "koa-router": "^8.0.8",
-        "mime-types": "^2.1.28",
-        "mkdirp": "^1.0.4",
-        "multer": "2.0.0-rc.2",
-        "pretty-bytes": "^5.5.0",
-        "tslib": "^2.1.0",
-        "underscore": "^1.12.0",
-        "yargs": "^16.2.0"
-    },
-    "devDependencies": {
-        "@sofie-automation/code-standard-preset": "^0.2.1",
-        "@types/jest": "^26.0.19",
-        "@types/koa": "^2.11.6",
-        "@types/koa-bodyparser": "^4.3.0",
-        "@types/koa-range": "^0.3.2",
-        "@types/koa-router": "^7.4.0",
-        "@types/koa__cors": "^3.0.2",
-        "@types/koa__multer": "^2.0.2",
-        "@types/mime-types": "^2.1.0",
-        "@types/mkdirp": "^1.0.1",
-        "@types/node": "^14.14.31",
-        "@types/underscore": "^1.10.24",
-        "@types/yargs": "^15.0.12",
-        "lint-staged": "^7.2.0",
-        "nexe": "^3.3.7"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "engines": {
-        "node": ">=14.18.0"
-    },
-    "lint-staged": {
-        "*.{js,css,json,md,scss}": [
-            "prettier"
-        ],
-        "*.{ts,tsx}": [
-            "eslint"
-        ]
-    }
+	"name": "@http-server/generic",
+	"version": "1.39.2",
+	"private": true,
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"scripts": {
+		"build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.json",
+		"__test": "jest",
+		"precommit": "lint-staged"
+	},
+	"peerDependencies": {},
+	"dependencies": {
+		"@koa/cors": "^3.0.0",
+		"@koa/multer": "3.0.0",
+		"@sofie-package-manager/api": "1.39.2",
+		"koa": "^2.11.0",
+		"koa-bodyparser": "^4.3.0",
+		"koa-range": "^0.3.0",
+		"koa-router": "^8.0.8",
+		"mime-types": "^2.1.28",
+		"mkdirp": "^1.0.4",
+		"multer": "2.0.0-rc.2",
+		"pretty-bytes": "^5.5.0",
+		"tslib": "^2.1.0",
+		"underscore": "^1.12.0",
+		"yargs": "^16.2.0"
+	},
+	"devDependencies": {
+		"@sofie-automation/code-standard-preset": "^0.2.1",
+		"@types/jest": "^26.0.19",
+		"@types/koa": "^2.11.6",
+		"@types/koa-bodyparser": "^4.3.0",
+		"@types/koa-range": "^0.3.2",
+		"@types/koa-router": "^7.4.0",
+		"@types/koa__cors": "^3.0.2",
+		"@types/koa__multer": "^2.0.2",
+		"@types/mime-types": "^2.1.0",
+		"@types/mkdirp": "^1.0.1",
+		"@types/node": "^14.14.31",
+		"@types/underscore": "^1.10.24",
+		"@types/yargs": "^15.0.12",
+		"lint-staged": "^7.2.0",
+		"nexe": "^3.3.7"
+	},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier"
+		],
+		"*.{ts,tsx}": [
+			"eslint"
+		]
+	}
 }

--- a/apps/http-server/packages/generic/package.json
+++ b/apps/http-server/packages/generic/package.json
@@ -1,59 +1,59 @@
 {
-	"name": "@http-server/generic",
-	"version": "1.39.2",
-	"private": true,
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"scripts": {
-		"build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"__test": "jest",
-		"precommit": "lint-staged"
-	},
-	"peerDependencies": {},
-	"dependencies": {
-		"@koa/cors": "^3.0.0",
-		"@koa/multer": "3.0.0",
-		"@sofie-package-manager/api": "1.39.2",
-		"koa": "^2.11.0",
-		"koa-bodyparser": "^4.3.0",
-		"koa-range": "^0.3.0",
-		"koa-router": "^8.0.8",
-		"mime-types": "^2.1.28",
-		"mkdirp": "^1.0.4",
-		"multer": "2.0.0-rc.2",
-		"pretty-bytes": "^5.5.0",
-		"tslib": "^2.1.0",
-		"underscore": "^1.12.0",
-		"yargs": "^16.2.0"
-	},
-	"devDependencies": {
-		"@sofie-automation/code-standard-preset": "^0.2.1",
-		"@types/jest": "^26.0.19",
-		"@types/koa": "^2.11.6",
-		"@types/koa-bodyparser": "^4.3.0",
-		"@types/koa-range": "^0.3.2",
-		"@types/koa-router": "^7.4.0",
-		"@types/koa__cors": "^3.0.2",
-		"@types/koa__multer": "^2.0.2",
-		"@types/mime-types": "^2.1.0",
-		"@types/mkdirp": "^1.0.1",
-		"@types/node": "^14.14.31",
-		"@types/underscore": "^1.10.24",
-		"@types/yargs": "^15.0.12",
-		"lint-staged": "^7.2.0",
-		"nexe": "^3.3.7"
-	},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@http-server/generic",
+  "version": "1.39.2",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "__test": "jest",
+    "precommit": "lint-staged"
+  },
+  "peerDependencies": {},
+  "dependencies": {
+    "@koa/cors": "^3.0.0",
+    "@koa/multer": "3.0.0",
+    "@sofie-package-manager/api": "1.39.2",
+    "koa": "^2.11.0",
+    "koa-bodyparser": "^4.3.0",
+    "koa-range": "^0.3.0",
+    "koa-router": "^8.0.8",
+    "mime-types": "^2.1.28",
+    "mkdirp": "^1.0.4",
+    "multer": "2.0.0-rc.2",
+    "pretty-bytes": "^5.5.0",
+    "tslib": "^2.1.0",
+    "underscore": "^1.12.0",
+    "yargs": "^16.2.0"
+  },
+  "devDependencies": {
+    "@sofie-automation/code-standard-preset": "^0.2.1",
+    "@types/jest": "^26.0.19",
+    "@types/koa": "^2.11.6",
+    "@types/koa-bodyparser": "^4.3.0",
+    "@types/koa-range": "^0.3.2",
+    "@types/koa-router": "^7.4.0",
+    "@types/koa__cors": "^3.0.2",
+    "@types/koa__multer": "^2.0.2",
+    "@types/mime-types": "^2.1.0",
+    "@types/mkdirp": "^1.0.1",
+    "@types/node": "^14.14.31",
+    "@types/underscore": "^1.10.24",
+    "@types/yargs": "^15.0.12",
+    "lint-staged": "^7.2.0",
+    "nexe": "^3.3.7"
+  },
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/apps/package-manager/app/package.json
+++ b/apps/package-manager/app/package.json
@@ -1,33 +1,33 @@
 {
-  "name": "@package-manager/app",
-  "version": "1.39.7",
-  "private": true,
-  "scripts": {
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js package-manager.exe && node ../../../scripts/copy-natives.js win32-x64",
-    "__test": "jest",
-    "start": "node dist/index.js",
-    "precommit": "lint-staged"
-  },
-  "devDependencies": {
-    "lint-staged": "^7.2.0",
-    "nexe": "^3.3.7"
-  },
-  "dependencies": {
-    "@package-manager/generic": "1.39.7"
-  },
-  "peerDependencies": {},
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
-    ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "name": "@package-manager/app",
+    "version": "1.39.7",
+    "private": true,
+    "scripts": {
+        "build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js package-manager.exe && node ../../../scripts/copy-natives.js win32-x64",
+        "__test": "jest",
+        "start": "node dist/index.js",
+        "precommit": "lint-staged"
+    },
+    "devDependencies": {
+        "lint-staged": "^7.2.0",
+        "nexe": "^3.3.7"
+    },
+    "dependencies": {
+        "@package-manager/generic": "1.39.7"
+    },
+    "peerDependencies": {},
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/apps/package-manager/app/package.json
+++ b/apps/package-manager/app/package.json
@@ -1,33 +1,33 @@
 {
-	"name": "@package-manager/app",
-	"version": "1.39.7",
-	"private": true,
-	"scripts": {
-		"build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"build-win32": "mkdir deploy & node ../../../scripts/build-win32.js package-manager.exe && node ../../../scripts/copy-natives.js win32-x64",
-		"__test": "jest",
-		"start": "node dist/index.js",
-		"precommit": "lint-staged"
-	},
-	"devDependencies": {
-		"lint-staged": "^7.2.0",
-		"nexe": "^3.3.7"
-	},
-	"dependencies": {
-		"@package-manager/generic": "1.39.7"
-	},
-	"peerDependencies": {},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@package-manager/app",
+  "version": "1.39.7",
+  "private": true,
+  "scripts": {
+    "build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js package-manager.exe && node ../../../scripts/copy-natives.js win32-x64",
+    "__test": "jest",
+    "start": "node dist/index.js",
+    "precommit": "lint-staged"
+  },
+  "devDependencies": {
+    "lint-staged": "^7.2.0",
+    "nexe": "^3.3.7"
+  },
+  "dependencies": {
+    "@package-manager/generic": "1.39.7"
+  },
+  "peerDependencies": {},
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/apps/package-manager/app/package.json
+++ b/apps/package-manager/app/package.json
@@ -1,35 +1,33 @@
 {
-    "name": "@package-manager/app",
-    "version": "1.39.7",
-    "private": true,
-    "scripts": {
-        "build": "rimraf dist && yarn build:main",
-        "build:main": "tsc -p tsconfig.json",
-        "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js package-manager.exe && node ../../../scripts/copy-natives.js win32-x64",
-        "__test": "jest",
-        "start": "node dist/index.js",
-        "precommit": "lint-staged"
-    },
-    "devDependencies": {
-        "lint-staged": "^7.2.0",
-        "nexe": "^3.3.7"
-    },
-    "dependencies": {
-        "@package-manager/generic": "1.39.7"
-    },
-    "peerDependencies": {
-        "@sofie-automation/blueprints-integration": "*"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "engines": {
-        "node": ">=14.18.0"
-    },
-    "lint-staged": {
-        "*.{js,css,json,md,scss}": [
-            "prettier"
-        ],
-        "*.{ts,tsx}": [
-            "eslint"
-        ]
-    }
+	"name": "@package-manager/app",
+	"version": "1.39.7",
+	"private": true,
+	"scripts": {
+		"build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.json",
+		"build-win32": "mkdir deploy & node ../../../scripts/build-win32.js package-manager.exe && node ../../../scripts/copy-natives.js win32-x64",
+		"__test": "jest",
+		"start": "node dist/index.js",
+		"precommit": "lint-staged"
+	},
+	"devDependencies": {
+		"lint-staged": "^7.2.0",
+		"nexe": "^3.3.7"
+	},
+	"dependencies": {
+		"@package-manager/generic": "1.39.7"
+	},
+	"peerDependencies": {},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier"
+		],
+		"*.{ts,tsx}": [
+			"eslint"
+		]
+	}
 }

--- a/apps/package-manager/packages/generic/package.json
+++ b/apps/package-manager/packages/generic/package.json
@@ -1,42 +1,42 @@
 {
-  "name": "@package-manager/generic",
-  "version": "1.39.7",
-  "private": true,
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "test": "jest",
-    "precommit": "lint-staged"
-  },
-  "peerDependencies": {
-    "@sofie-automation/server-core-integration": "*"
-  },
-  "dependencies": {
-    "@sofie-package-manager/api": "1.39.2",
-    "@sofie-package-manager/expectation-manager": "1.39.7",
-    "@sofie-package-manager/worker": "1.39.7",
-    "chokidar": "^3.5.1",
-    "deep-extend": "^0.6.0",
-    "fast-clone": "^1.5.13",
-    "underscore": "^1.12.0"
-  },
-  "devDependencies": {
-    "@types/deep-extend": "0.4.31",
-    "@types/underscore": "^1.10.24",
-    "lint-staged": "^7.2.0"
-  },
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
-    ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "name": "@package-manager/generic",
+    "version": "1.39.7",
+    "private": true,
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "scripts": {
+        "build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "test": "jest",
+        "precommit": "lint-staged"
+    },
+    "peerDependencies": {
+        "@sofie-automation/server-core-integration": "*"
+    },
+    "dependencies": {
+        "@sofie-package-manager/api": "1.39.2",
+        "@sofie-package-manager/expectation-manager": "1.39.7",
+        "@sofie-package-manager/worker": "1.39.7",
+        "chokidar": "^3.5.1",
+        "deep-extend": "^0.6.0",
+        "fast-clone": "^1.5.13",
+        "underscore": "^1.12.0"
+    },
+    "devDependencies": {
+        "@types/deep-extend": "0.4.31",
+        "@types/underscore": "^1.10.24",
+        "lint-staged": "^7.2.0"
+    },
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/apps/package-manager/packages/generic/package.json
+++ b/apps/package-manager/packages/generic/package.json
@@ -1,42 +1,42 @@
 {
-	"name": "@package-manager/generic",
-	"version": "1.39.7",
-	"private": true,
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"scripts": {
-		"build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"test": "jest",
-		"precommit": "lint-staged"
-	},
-	"peerDependencies": {
-		"@sofie-automation/server-core-integration": "*"
-	},
-	"dependencies": {
-		"@sofie-package-manager/api": "1.39.2",
-		"@sofie-package-manager/expectation-manager": "1.39.7",
-		"@sofie-package-manager/worker": "1.39.7",
-		"chokidar": "^3.5.1",
-		"deep-extend": "^0.6.0",
-		"fast-clone": "^1.5.13",
-		"underscore": "^1.12.0"
-	},
-	"devDependencies": {
-		"@types/deep-extend": "0.4.31",
-		"@types/underscore": "^1.10.24",
-		"lint-staged": "^7.2.0"
-	},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@package-manager/generic",
+  "version": "1.39.7",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "test": "jest",
+    "precommit": "lint-staged"
+  },
+  "peerDependencies": {
+    "@sofie-automation/server-core-integration": "*"
+  },
+  "dependencies": {
+    "@sofie-package-manager/api": "1.39.2",
+    "@sofie-package-manager/expectation-manager": "1.39.7",
+    "@sofie-package-manager/worker": "1.39.7",
+    "chokidar": "^3.5.1",
+    "deep-extend": "^0.6.0",
+    "fast-clone": "^1.5.13",
+    "underscore": "^1.12.0"
+  },
+  "devDependencies": {
+    "@types/deep-extend": "0.4.31",
+    "@types/underscore": "^1.10.24",
+    "lint-staged": "^7.2.0"
+  },
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/apps/package-manager/packages/generic/package.json
+++ b/apps/package-manager/packages/generic/package.json
@@ -1,43 +1,42 @@
 {
-    "name": "@package-manager/generic",
-    "version": "1.39.7",
-    "private": true,
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "scripts": {
-        "build": "rimraf dist && yarn build:main",
-        "build:main": "tsc -p tsconfig.json",
-        "test": "jest",
-        "precommit": "lint-staged"
-    },
-    "peerDependencies": {
-        "@sofie-automation/blueprints-integration": "*",
-        "@sofie-automation/server-core-integration": "*"
-    },
-    "dependencies": {
-        "@sofie-package-manager/api": "1.39.2",
-        "@sofie-package-manager/expectation-manager": "1.39.7",
-        "@sofie-package-manager/worker": "1.39.7",
-        "chokidar": "^3.5.1",
-        "deep-extend": "^0.6.0",
-        "fast-clone": "^1.5.13",
-        "underscore": "^1.12.0"
-    },
-    "devDependencies": {
-        "@types/deep-extend": "0.4.31",
-        "@types/underscore": "^1.10.24",
-        "lint-staged": "^7.2.0"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "engines": {
-        "node": ">=14.18.0"
-    },
-    "lint-staged": {
-        "*.{js,css,json,md,scss}": [
-            "prettier"
-        ],
-        "*.{ts,tsx}": [
-            "eslint"
-        ]
-    }
+	"name": "@package-manager/generic",
+	"version": "1.39.7",
+	"private": true,
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"scripts": {
+		"build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.json",
+		"test": "jest",
+		"precommit": "lint-staged"
+	},
+	"peerDependencies": {
+		"@sofie-automation/server-core-integration": "*"
+	},
+	"dependencies": {
+		"@sofie-package-manager/api": "1.39.2",
+		"@sofie-package-manager/expectation-manager": "1.39.7",
+		"@sofie-package-manager/worker": "1.39.7",
+		"chokidar": "^3.5.1",
+		"deep-extend": "^0.6.0",
+		"fast-clone": "^1.5.13",
+		"underscore": "^1.12.0"
+	},
+	"devDependencies": {
+		"@types/deep-extend": "0.4.31",
+		"@types/underscore": "^1.10.24",
+		"lint-staged": "^7.2.0"
+	},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier"
+		],
+		"*.{ts,tsx}": [
+			"eslint"
+		]
+	}
 }

--- a/apps/package-manager/packages/generic/src/api.ts
+++ b/apps/package-manager/packages/generic/src/api.ts
@@ -1,4 +1,5 @@
-import { ExpectedPackageStatusAPI } from '@sofie-automation/blueprints-integration'
+// eslint-disable-next-line node/no-extraneous-import
+import { ExpectedPackageStatusAPI } from '@sofie-automation/shared-lib/dist/package-manager/package'
 
 /** Note: This is based on the Core method updateExpectedPackageWorkStatuses. */
 export type UpdateExpectedPackageWorkStatusesChanges = (

--- a/apps/package-manager/packages/generic/src/packageManager.ts
+++ b/apps/package-manager/packages/generic/src/packageManager.ts
@@ -2,7 +2,8 @@ import _ from 'underscore'
 import { CoreHandler } from './coreHandler'
 // eslint-disable-next-line node/no-extraneous-import
 import { PeripheralDeviceAPIMethods } from '@sofie-automation/shared-lib/dist/peripheralDevice/methodsAPI'
-import { ExpectedPackageStatusAPI } from '@sofie-automation/blueprints-integration'
+// eslint-disable-next-line node/no-extraneous-import
+import { ExpectedPackageStatusAPI } from '@sofie-automation/shared-lib/dist/package-manager/package'
 import {
 	ExpectationManager,
 	ExpectationManagerCallbacks,

--- a/apps/package-manager/packages/generic/src/packageManager.ts
+++ b/apps/package-manager/packages/generic/src/packageManager.ts
@@ -1,6 +1,7 @@
 import _ from 'underscore'
-import { PeripheralDeviceAPI } from '@sofie-automation/server-core-integration'
 import { CoreHandler } from './coreHandler'
+// eslint-disable-next-line node/no-extraneous-import
+import { PeripheralDeviceAPIMethods } from '@sofie-automation/shared-lib/dist/peripheralDevice/methodsAPI'
 import { ExpectedPackageStatusAPI } from '@sofie-automation/blueprints-integration'
 import {
 	ExpectationManager,
@@ -586,21 +587,21 @@ class ExpectationManagerCallbacksHandler implements ExpectationManagerCallbacks 
 			case 'fetchPackageInfoMetadata': {
 				if (this.packageManager.coreHandler.notUsingCore) return // Abort if we are not using core
 				return this.packageManager.coreHandler.callMethod(
-					PeripheralDeviceAPI.methods.fetchPackageInfoMetadata,
+					PeripheralDeviceAPIMethods.fetchPackageInfoMetadata,
 					message.arguments
 				)
 			}
 			case 'updatePackageInfo': {
 				if (this.packageManager.coreHandler.notUsingCore) return // Abort if we are not using core
 				return this.packageManager.coreHandler.callMethod(
-					PeripheralDeviceAPI.methods.updatePackageInfo,
+					PeripheralDeviceAPIMethods.updatePackageInfo,
 					message.arguments
 				)
 			}
 			case 'removePackageInfo': {
 				if (this.packageManager.coreHandler.notUsingCore) return // Abort if we are not using core
 				return this.packageManager.coreHandler.callMethod(
-					PeripheralDeviceAPI.methods.removePackageInfo,
+					PeripheralDeviceAPIMethods.removePackageInfo,
 					message.arguments
 				)
 			}
@@ -620,19 +621,19 @@ class ExpectationManagerCallbacksHandler implements ExpectationManagerCallbacks 
 
 		this.reportedExpectationStatuses = {}
 		await this.packageManager.coreHandler.callMethod(
-			PeripheralDeviceAPI.methods.removeAllExpectedPackageWorkStatusOfDevice,
+			PeripheralDeviceAPIMethods.removeAllExpectedPackageWorkStatusOfDevice,
 			[]
 		)
 
 		this.reportedPackageContainerStatuses = {}
 		await this.packageManager.coreHandler.callMethod(
-			PeripheralDeviceAPI.methods.removeAllPackageContainerPackageStatusesOfDevice,
+			PeripheralDeviceAPIMethods.removeAllPackageContainerPackageStatusesOfDevice,
 			[]
 		)
 
 		this.reportedPackageStatuses = {}
 		await this.packageManager.coreHandler.callMethod(
-			PeripheralDeviceAPI.methods.removeAllPackageContainerStatusesOfDevice,
+			PeripheralDeviceAPIMethods.removeAllPackageContainerStatusesOfDevice,
 			[]
 		)
 	}
@@ -767,7 +768,7 @@ class ExpectationManagerCallbacksHandler implements ExpectationManagerCallbacks 
 
 				try {
 					await this.packageManager.coreHandler.callMethod(
-						PeripheralDeviceAPI.methods.updateExpectedPackageWorkStatuses,
+						PeripheralDeviceAPIMethods.updateExpectedPackageWorkStatuses,
 						[sendToCore]
 					)
 				} catch (err) {
@@ -786,7 +787,7 @@ class ExpectationManagerCallbacksHandler implements ExpectationManagerCallbacks 
 		await this.reportStatus(this.toReportPackageStatus, this.reportedPackageStatuses, async (changesToSend) => {
 			// Send the changes to Core:
 			await this.packageManager.coreHandler.callMethod(
-				PeripheralDeviceAPI.methods.updatePackageContainerPackageStatuses,
+				PeripheralDeviceAPIMethods.updatePackageContainerPackageStatuses,
 				[
 					literal<UpdatePackageContainerPackageStatusesChanges>(
 						changesToSend.map((change) => {
@@ -819,7 +820,7 @@ class ExpectationManagerCallbacksHandler implements ExpectationManagerCallbacks 
 				// Send the changes to Core:
 				literal<UpdatePackageContainerStatusesChanges>(
 					await this.packageManager.coreHandler.callMethod(
-						PeripheralDeviceAPI.methods.updatePackageContainerStatuses,
+						PeripheralDeviceAPIMethods.updatePackageContainerStatuses,
 						[
 							changesToSend.map((change) => {
 								if (change.type === 'delete') {

--- a/apps/quantel-http-transformer-proxy/app/package.json
+++ b/apps/quantel-http-transformer-proxy/app/package.json
@@ -1,35 +1,33 @@
 {
-    "name": "@quantel-http-transformer-proxy/app",
-    "version": "1.39.7",
-    "description": "Proxy for a Quantel HTTP Transformer",
-    "private": true,
-    "scripts": {
-        "build": "rimraf dist && yarn build:main",
-        "build:main": "tsc -p tsconfig.json",
-        "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js quantel-http-transformer-proxy.exe && node ../../../scripts/copy-natives.js win32-x64",
-        "start": "node dist/index.js",
-        "precommit": "lint-staged"
-    },
-    "devDependencies": {
-        "lint-staged": "^7.2.0",
-        "nexe": "^3.3.7"
-    },
-    "dependencies": {
-        "@quantel-http-transformer-proxy/generic": "1.39.7"
-    },
-    "peerDependencies": {
-        "@sofie-automation/blueprints-integration": "*"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "engines": {
-        "node": ">=14.18.0"
-    },
-    "lint-staged": {
-        "*.{js,css,json,md,scss}": [
-            "prettier"
-        ],
-        "*.{ts,tsx}": [
-            "eslint"
-        ]
-    }
+	"name": "@quantel-http-transformer-proxy/app",
+	"version": "1.39.7",
+	"description": "Proxy for a Quantel HTTP Transformer",
+	"private": true,
+	"scripts": {
+		"build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.json",
+		"build-win32": "mkdir deploy & node ../../../scripts/build-win32.js quantel-http-transformer-proxy.exe && node ../../../scripts/copy-natives.js win32-x64",
+		"start": "node dist/index.js",
+		"precommit": "lint-staged"
+	},
+	"devDependencies": {
+		"lint-staged": "^7.2.0",
+		"nexe": "^3.3.7"
+	},
+	"dependencies": {
+		"@quantel-http-transformer-proxy/generic": "1.39.7"
+	},
+	"peerDependencies": {},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier"
+		],
+		"*.{ts,tsx}": [
+			"eslint"
+		]
+	}
 }

--- a/apps/quantel-http-transformer-proxy/app/package.json
+++ b/apps/quantel-http-transformer-proxy/app/package.json
@@ -1,33 +1,33 @@
 {
-  "name": "@quantel-http-transformer-proxy/app",
-  "version": "1.39.7",
-  "description": "Proxy for a Quantel HTTP Transformer",
-  "private": true,
-  "scripts": {
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js quantel-http-transformer-proxy.exe && node ../../../scripts/copy-natives.js win32-x64",
-    "start": "node dist/index.js",
-    "precommit": "lint-staged"
-  },
-  "devDependencies": {
-    "lint-staged": "^7.2.0",
-    "nexe": "^3.3.7"
-  },
-  "dependencies": {
-    "@quantel-http-transformer-proxy/generic": "1.39.7"
-  },
-  "peerDependencies": {},
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
-    ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "name": "@quantel-http-transformer-proxy/app",
+    "version": "1.39.7",
+    "description": "Proxy for a Quantel HTTP Transformer",
+    "private": true,
+    "scripts": {
+        "build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js quantel-http-transformer-proxy.exe && node ../../../scripts/copy-natives.js win32-x64",
+        "start": "node dist/index.js",
+        "precommit": "lint-staged"
+    },
+    "devDependencies": {
+        "lint-staged": "^7.2.0",
+        "nexe": "^3.3.7"
+    },
+    "dependencies": {
+        "@quantel-http-transformer-proxy/generic": "1.39.7"
+    },
+    "peerDependencies": {},
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/apps/quantel-http-transformer-proxy/app/package.json
+++ b/apps/quantel-http-transformer-proxy/app/package.json
@@ -1,33 +1,33 @@
 {
-	"name": "@quantel-http-transformer-proxy/app",
-	"version": "1.39.7",
-	"description": "Proxy for a Quantel HTTP Transformer",
-	"private": true,
-	"scripts": {
-		"build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"build-win32": "mkdir deploy & node ../../../scripts/build-win32.js quantel-http-transformer-proxy.exe && node ../../../scripts/copy-natives.js win32-x64",
-		"start": "node dist/index.js",
-		"precommit": "lint-staged"
-	},
-	"devDependencies": {
-		"lint-staged": "^7.2.0",
-		"nexe": "^3.3.7"
-	},
-	"dependencies": {
-		"@quantel-http-transformer-proxy/generic": "1.39.7"
-	},
-	"peerDependencies": {},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@quantel-http-transformer-proxy/app",
+  "version": "1.39.7",
+  "description": "Proxy for a Quantel HTTP Transformer",
+  "private": true,
+  "scripts": {
+    "build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js quantel-http-transformer-proxy.exe && node ../../../scripts/copy-natives.js win32-x64",
+    "start": "node dist/index.js",
+    "precommit": "lint-staged"
+  },
+  "devDependencies": {
+    "lint-staged": "^7.2.0",
+    "nexe": "^3.3.7"
+  },
+  "dependencies": {
+    "@quantel-http-transformer-proxy/generic": "1.39.7"
+  },
+  "peerDependencies": {},
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/apps/quantel-http-transformer-proxy/packages/generic/package.json
+++ b/apps/quantel-http-transformer-proxy/packages/generic/package.json
@@ -1,68 +1,66 @@
 {
-    "name": "@quantel-http-transformer-proxy/generic",
-    "version": "1.39.7",
-    "private": true,
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "scripts": {
-        "build": "rimraf dist && yarn build:main",
-        "build:main": "tsc -p tsconfig.json",
-        "__test": "jest",
-        "precommit": "lint-staged"
-    },
-    "peerDependencies": {
-        "@sofie-automation/blueprints-integration": "*"
-    },
-    "dependencies": {
-        "@koa/cors": "^3.0.0",
-        "@koa/multer": "3.0.0",
-        "@sofie-package-manager/api": "1.39.2",
-        "got": "^11.8.6",
-        "koa": "^2.11.0",
-        "koa-bodyparser": "^4.3.0",
-        "koa-range": "^0.3.0",
-        "koa-ratelimit": "^5.0.1",
-        "koa-router": "^8.0.8",
-        "mime-types": "^2.1.28",
-        "mkdirp": "^1.0.4",
-        "multer": "2.0.0-rc.2",
-        "pretty-bytes": "^5.5.0",
-        "tslib": "^2.1.0",
-        "underscore": "^1.12.0",
-        "xml2js": "^0.4.23",
-        "yargs": "^16.2.0"
-    },
-    "devDependencies": {
-        "@koa/cors": "^3.0.0",
-        "@koa/multer": "3.0.0",
-        "@sofie-automation/code-standard-preset": "^0.2.1",
-        "@types/jest": "^26.0.19",
-        "@types/koa": "^2.11.6",
-        "@types/koa-bodyparser": "^4.3.0",
-        "@types/koa-range": "^0.3.2",
-        "@types/koa-ratelimit": "^4.2.4",
-        "@types/koa-router": "^7.4.0",
-        "@types/koa__cors": "^3.0.2",
-        "@types/koa__multer": "^2.0.2",
-        "@types/mime-types": "^2.1.0",
-        "@types/mkdirp": "^1.0.1",
-        "@types/node": "^14.14.31",
-        "@types/underscore": "^1.10.24",
-        "@types/xml2js": "^0.4.7",
-        "@types/yargs": "^15.0.12",
-        "lint-staged": "^7.2.0",
-        "nexe": "^3.3.7"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "engines": {
-        "node": ">=14.18.0"
-    },
-    "lint-staged": {
-        "*.{js,css,json,md,scss}": [
-            "prettier"
-        ],
-        "*.{ts,tsx}": [
-            "eslint"
-        ]
-    }
+	"name": "@quantel-http-transformer-proxy/generic",
+	"version": "1.39.7",
+	"private": true,
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"scripts": {
+		"build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.json",
+		"__test": "jest",
+		"precommit": "lint-staged"
+	},
+	"peerDependencies": {},
+	"dependencies": {
+		"@koa/cors": "^3.0.0",
+		"@koa/multer": "3.0.0",
+		"@sofie-package-manager/api": "1.39.2",
+		"got": "^11.8.6",
+		"koa": "^2.11.0",
+		"koa-bodyparser": "^4.3.0",
+		"koa-range": "^0.3.0",
+		"koa-ratelimit": "^5.0.1",
+		"koa-router": "^8.0.8",
+		"mime-types": "^2.1.28",
+		"mkdirp": "^1.0.4",
+		"multer": "2.0.0-rc.2",
+		"pretty-bytes": "^5.5.0",
+		"tslib": "^2.1.0",
+		"underscore": "^1.12.0",
+		"xml2js": "^0.4.23",
+		"yargs": "^16.2.0"
+	},
+	"devDependencies": {
+		"@koa/cors": "^3.0.0",
+		"@koa/multer": "3.0.0",
+		"@sofie-automation/code-standard-preset": "^0.2.1",
+		"@types/jest": "^26.0.19",
+		"@types/koa": "^2.11.6",
+		"@types/koa-bodyparser": "^4.3.0",
+		"@types/koa-range": "^0.3.2",
+		"@types/koa-ratelimit": "^4.2.4",
+		"@types/koa-router": "^7.4.0",
+		"@types/koa__cors": "^3.0.2",
+		"@types/koa__multer": "^2.0.2",
+		"@types/mime-types": "^2.1.0",
+		"@types/mkdirp": "^1.0.1",
+		"@types/node": "^14.14.31",
+		"@types/underscore": "^1.10.24",
+		"@types/xml2js": "^0.4.7",
+		"@types/yargs": "^15.0.12",
+		"lint-staged": "^7.2.0",
+		"nexe": "^3.3.7"
+	},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier"
+		],
+		"*.{ts,tsx}": [
+			"eslint"
+		]
+	}
 }

--- a/apps/quantel-http-transformer-proxy/packages/generic/package.json
+++ b/apps/quantel-http-transformer-proxy/packages/generic/package.json
@@ -1,66 +1,66 @@
 {
-  "name": "@quantel-http-transformer-proxy/generic",
-  "version": "1.39.7",
-  "private": true,
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "__test": "jest",
-    "precommit": "lint-staged"
-  },
-  "peerDependencies": {},
-  "dependencies": {
-    "@koa/cors": "^3.0.0",
-    "@koa/multer": "3.0.0",
-    "@sofie-package-manager/api": "1.39.2",
-    "got": "^11.8.6",
-    "koa": "^2.11.0",
-    "koa-bodyparser": "^4.3.0",
-    "koa-range": "^0.3.0",
-    "koa-ratelimit": "^5.0.1",
-    "koa-router": "^8.0.8",
-    "mime-types": "^2.1.28",
-    "mkdirp": "^1.0.4",
-    "multer": "2.0.0-rc.2",
-    "pretty-bytes": "^5.5.0",
-    "tslib": "^2.1.0",
-    "underscore": "^1.12.0",
-    "xml2js": "^0.4.23",
-    "yargs": "^16.2.0"
-  },
-  "devDependencies": {
-    "@koa/cors": "^3.0.0",
-    "@koa/multer": "3.0.0",
-    "@sofie-automation/code-standard-preset": "^0.2.1",
-    "@types/jest": "^26.0.19",
-    "@types/koa": "^2.11.6",
-    "@types/koa-bodyparser": "^4.3.0",
-    "@types/koa-range": "^0.3.2",
-    "@types/koa-ratelimit": "^4.2.4",
-    "@types/koa-router": "^7.4.0",
-    "@types/koa__cors": "^3.0.2",
-    "@types/koa__multer": "^2.0.2",
-    "@types/mime-types": "^2.1.0",
-    "@types/mkdirp": "^1.0.1",
-    "@types/node": "^14.14.31",
-    "@types/underscore": "^1.10.24",
-    "@types/xml2js": "^0.4.7",
-    "@types/yargs": "^15.0.12",
-    "lint-staged": "^7.2.0",
-    "nexe": "^3.3.7"
-  },
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
-    ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "name": "@quantel-http-transformer-proxy/generic",
+    "version": "1.39.7",
+    "private": true,
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "scripts": {
+        "build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "__test": "jest",
+        "precommit": "lint-staged"
+    },
+    "peerDependencies": {},
+    "dependencies": {
+        "@koa/cors": "^3.0.0",
+        "@koa/multer": "3.0.0",
+        "@sofie-package-manager/api": "1.39.2",
+        "got": "^11.8.6",
+        "koa": "^2.11.0",
+        "koa-bodyparser": "^4.3.0",
+        "koa-range": "^0.3.0",
+        "koa-ratelimit": "^5.0.1",
+        "koa-router": "^8.0.8",
+        "mime-types": "^2.1.28",
+        "mkdirp": "^1.0.4",
+        "multer": "2.0.0-rc.2",
+        "pretty-bytes": "^5.5.0",
+        "tslib": "^2.1.0",
+        "underscore": "^1.12.0",
+        "xml2js": "^0.4.23",
+        "yargs": "^16.2.0"
+    },
+    "devDependencies": {
+        "@koa/cors": "^3.0.0",
+        "@koa/multer": "3.0.0",
+        "@sofie-automation/code-standard-preset": "^0.2.1",
+        "@types/jest": "^26.0.19",
+        "@types/koa": "^2.11.6",
+        "@types/koa-bodyparser": "^4.3.0",
+        "@types/koa-range": "^0.3.2",
+        "@types/koa-ratelimit": "^4.2.4",
+        "@types/koa-router": "^7.4.0",
+        "@types/koa__cors": "^3.0.2",
+        "@types/koa__multer": "^2.0.2",
+        "@types/mime-types": "^2.1.0",
+        "@types/mkdirp": "^1.0.1",
+        "@types/node": "^14.14.31",
+        "@types/underscore": "^1.10.24",
+        "@types/xml2js": "^0.4.7",
+        "@types/yargs": "^15.0.12",
+        "lint-staged": "^7.2.0",
+        "nexe": "^3.3.7"
+    },
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/apps/quantel-http-transformer-proxy/packages/generic/package.json
+++ b/apps/quantel-http-transformer-proxy/packages/generic/package.json
@@ -1,66 +1,66 @@
 {
-	"name": "@quantel-http-transformer-proxy/generic",
-	"version": "1.39.7",
-	"private": true,
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"scripts": {
-		"build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"__test": "jest",
-		"precommit": "lint-staged"
-	},
-	"peerDependencies": {},
-	"dependencies": {
-		"@koa/cors": "^3.0.0",
-		"@koa/multer": "3.0.0",
-		"@sofie-package-manager/api": "1.39.2",
-		"got": "^11.8.6",
-		"koa": "^2.11.0",
-		"koa-bodyparser": "^4.3.0",
-		"koa-range": "^0.3.0",
-		"koa-ratelimit": "^5.0.1",
-		"koa-router": "^8.0.8",
-		"mime-types": "^2.1.28",
-		"mkdirp": "^1.0.4",
-		"multer": "2.0.0-rc.2",
-		"pretty-bytes": "^5.5.0",
-		"tslib": "^2.1.0",
-		"underscore": "^1.12.0",
-		"xml2js": "^0.4.23",
-		"yargs": "^16.2.0"
-	},
-	"devDependencies": {
-		"@koa/cors": "^3.0.0",
-		"@koa/multer": "3.0.0",
-		"@sofie-automation/code-standard-preset": "^0.2.1",
-		"@types/jest": "^26.0.19",
-		"@types/koa": "^2.11.6",
-		"@types/koa-bodyparser": "^4.3.0",
-		"@types/koa-range": "^0.3.2",
-		"@types/koa-ratelimit": "^4.2.4",
-		"@types/koa-router": "^7.4.0",
-		"@types/koa__cors": "^3.0.2",
-		"@types/koa__multer": "^2.0.2",
-		"@types/mime-types": "^2.1.0",
-		"@types/mkdirp": "^1.0.1",
-		"@types/node": "^14.14.31",
-		"@types/underscore": "^1.10.24",
-		"@types/xml2js": "^0.4.7",
-		"@types/yargs": "^15.0.12",
-		"lint-staged": "^7.2.0",
-		"nexe": "^3.3.7"
-	},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@quantel-http-transformer-proxy/generic",
+  "version": "1.39.7",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "__test": "jest",
+    "precommit": "lint-staged"
+  },
+  "peerDependencies": {},
+  "dependencies": {
+    "@koa/cors": "^3.0.0",
+    "@koa/multer": "3.0.0",
+    "@sofie-package-manager/api": "1.39.2",
+    "got": "^11.8.6",
+    "koa": "^2.11.0",
+    "koa-bodyparser": "^4.3.0",
+    "koa-range": "^0.3.0",
+    "koa-ratelimit": "^5.0.1",
+    "koa-router": "^8.0.8",
+    "mime-types": "^2.1.28",
+    "mkdirp": "^1.0.4",
+    "multer": "2.0.0-rc.2",
+    "pretty-bytes": "^5.5.0",
+    "tslib": "^2.1.0",
+    "underscore": "^1.12.0",
+    "xml2js": "^0.4.23",
+    "yargs": "^16.2.0"
+  },
+  "devDependencies": {
+    "@koa/cors": "^3.0.0",
+    "@koa/multer": "3.0.0",
+    "@sofie-automation/code-standard-preset": "^0.2.1",
+    "@types/jest": "^26.0.19",
+    "@types/koa": "^2.11.6",
+    "@types/koa-bodyparser": "^4.3.0",
+    "@types/koa-range": "^0.3.2",
+    "@types/koa-ratelimit": "^4.2.4",
+    "@types/koa-router": "^7.4.0",
+    "@types/koa__cors": "^3.0.2",
+    "@types/koa__multer": "^2.0.2",
+    "@types/mime-types": "^2.1.0",
+    "@types/mkdirp": "^1.0.1",
+    "@types/node": "^14.14.31",
+    "@types/underscore": "^1.10.24",
+    "@types/xml2js": "^0.4.7",
+    "@types/yargs": "^15.0.12",
+    "lint-staged": "^7.2.0",
+    "nexe": "^3.3.7"
+  },
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/apps/single-app/app/package.json
+++ b/apps/single-app/app/package.json
@@ -1,41 +1,41 @@
 {
-	"name": "@single-app/app",
-	"version": "1.39.7",
-	"description": "Package Manager, http-proxy etc.. all in one application",
-	"private": true,
-	"scripts": {
-		"build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"build-win32": "mkdir deploy & node ../../../scripts/build-win32.js package-manager-single-app.exe && node ../../../scripts/copy-natives.js win32-x64",
-		"__test": "jest",
-		"start": "node --inspect dist/index.js",
-		"precommit": "lint-staged"
-	},
-	"devDependencies": {
-		"lint-staged": "^7.2.0",
-		"nexe": "^3.3.7"
-	},
-	"dependencies": {
-		"@appcontainer-node/generic": "1.39.7",
-		"@http-server/generic": "1.39.2",
-		"@package-manager/generic": "1.39.7",
-		"@quantel-http-transformer-proxy/generic": "1.39.7",
-		"@sofie-package-manager/api": "1.39.2",
-		"@sofie-package-manager/worker": "1.39.7",
-		"@sofie-package-manager/workforce": "1.39.2",
-		"underscore": "^1.12.0"
-	},
-	"peerDependencies": {},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@single-app/app",
+  "version": "1.39.7",
+  "description": "Package Manager, http-proxy etc.. all in one application",
+  "private": true,
+  "scripts": {
+    "build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js package-manager-single-app.exe && node ../../../scripts/copy-natives.js win32-x64",
+    "__test": "jest",
+    "start": "node --inspect dist/index.js",
+    "precommit": "lint-staged"
+  },
+  "devDependencies": {
+    "lint-staged": "^7.2.0",
+    "nexe": "^3.3.7"
+  },
+  "dependencies": {
+    "@appcontainer-node/generic": "1.39.7",
+    "@http-server/generic": "1.39.2",
+    "@package-manager/generic": "1.39.7",
+    "@quantel-http-transformer-proxy/generic": "1.39.7",
+    "@sofie-package-manager/api": "1.39.2",
+    "@sofie-package-manager/worker": "1.39.7",
+    "@sofie-package-manager/workforce": "1.39.2",
+    "underscore": "^1.12.0"
+  },
+  "peerDependencies": {},
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/apps/single-app/app/package.json
+++ b/apps/single-app/app/package.json
@@ -1,41 +1,41 @@
 {
-  "name": "@single-app/app",
-  "version": "1.39.7",
-  "description": "Package Manager, http-proxy etc.. all in one application",
-  "private": true,
-  "scripts": {
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js package-manager-single-app.exe && node ../../../scripts/copy-natives.js win32-x64",
-    "__test": "jest",
-    "start": "node --inspect dist/index.js",
-    "precommit": "lint-staged"
-  },
-  "devDependencies": {
-    "lint-staged": "^7.2.0",
-    "nexe": "^3.3.7"
-  },
-  "dependencies": {
-    "@appcontainer-node/generic": "1.39.7",
-    "@http-server/generic": "1.39.2",
-    "@package-manager/generic": "1.39.7",
-    "@quantel-http-transformer-proxy/generic": "1.39.7",
-    "@sofie-package-manager/api": "1.39.2",
-    "@sofie-package-manager/worker": "1.39.7",
-    "@sofie-package-manager/workforce": "1.39.2",
-    "underscore": "^1.12.0"
-  },
-  "peerDependencies": {},
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
-    ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "name": "@single-app/app",
+    "version": "1.39.7",
+    "description": "Package Manager, http-proxy etc.. all in one application",
+    "private": true,
+    "scripts": {
+        "build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js package-manager-single-app.exe && node ../../../scripts/copy-natives.js win32-x64",
+        "__test": "jest",
+        "start": "node --inspect dist/index.js",
+        "precommit": "lint-staged"
+    },
+    "devDependencies": {
+        "lint-staged": "^7.2.0",
+        "nexe": "^3.3.7"
+    },
+    "dependencies": {
+        "@appcontainer-node/generic": "1.39.7",
+        "@http-server/generic": "1.39.2",
+        "@package-manager/generic": "1.39.7",
+        "@quantel-http-transformer-proxy/generic": "1.39.7",
+        "@sofie-package-manager/api": "1.39.2",
+        "@sofie-package-manager/worker": "1.39.7",
+        "@sofie-package-manager/workforce": "1.39.2",
+        "underscore": "^1.12.0"
+    },
+    "peerDependencies": {},
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/apps/single-app/app/package.json
+++ b/apps/single-app/app/package.json
@@ -1,43 +1,41 @@
 {
-    "name": "@single-app/app",
-    "version": "1.39.7",
-    "description": "Package Manager, http-proxy etc.. all in one application",
-    "private": true,
-    "scripts": {
-        "build": "rimraf dist && yarn build:main",
-        "build:main": "tsc -p tsconfig.json",
-        "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js package-manager-single-app.exe && node ../../../scripts/copy-natives.js win32-x64",
-        "__test": "jest",
-        "start": "node --inspect dist/index.js",
-        "precommit": "lint-staged"
-    },
-    "devDependencies": {
-        "lint-staged": "^7.2.0",
-        "nexe": "^3.3.7"
-    },
-    "dependencies": {
-        "@appcontainer-node/generic": "1.39.7",
-        "@http-server/generic": "1.39.2",
-        "@package-manager/generic": "1.39.7",
-        "@quantel-http-transformer-proxy/generic": "1.39.7",
-        "@sofie-package-manager/api": "1.39.2",
-        "@sofie-package-manager/worker": "1.39.7",
-        "@sofie-package-manager/workforce": "1.39.2",
-        "underscore": "^1.12.0"
-    },
-    "peerDependencies": {
-        "@sofie-automation/blueprints-integration": "*"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "engines": {
-        "node": ">=14.18.0"
-    },
-    "lint-staged": {
-        "*.{js,css,json,md,scss}": [
-            "prettier"
-        ],
-        "*.{ts,tsx}": [
-            "eslint"
-        ]
-    }
+	"name": "@single-app/app",
+	"version": "1.39.7",
+	"description": "Package Manager, http-proxy etc.. all in one application",
+	"private": true,
+	"scripts": {
+		"build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.json",
+		"build-win32": "mkdir deploy & node ../../../scripts/build-win32.js package-manager-single-app.exe && node ../../../scripts/copy-natives.js win32-x64",
+		"__test": "jest",
+		"start": "node --inspect dist/index.js",
+		"precommit": "lint-staged"
+	},
+	"devDependencies": {
+		"lint-staged": "^7.2.0",
+		"nexe": "^3.3.7"
+	},
+	"dependencies": {
+		"@appcontainer-node/generic": "1.39.7",
+		"@http-server/generic": "1.39.2",
+		"@package-manager/generic": "1.39.7",
+		"@quantel-http-transformer-proxy/generic": "1.39.7",
+		"@sofie-package-manager/api": "1.39.2",
+		"@sofie-package-manager/worker": "1.39.7",
+		"@sofie-package-manager/workforce": "1.39.2",
+		"underscore": "^1.12.0"
+	},
+	"peerDependencies": {},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier"
+		],
+		"*.{ts,tsx}": [
+			"eslint"
+		]
+	}
 }

--- a/apps/worker/app/package.json
+++ b/apps/worker/app/package.json
@@ -1,37 +1,35 @@
 {
-    "name": "@worker/app",
-    "version": "1.39.7",
-    "description": "Boilerplace",
-    "private": true,
-    "scripts": {
-        "build": "rimraf dist && yarn build:main",
-        "build:main": "tsc -p tsconfig.json",
-        "oldbuild-win32": "mkdir deploy & rimraf deploy/worker.exe  && nexe dist/index.js -t windows-x64-12.18.1 -o deploy/worker.exe && node scripts/copy-natives.js win32-x64",
-        "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js worker.exe && node ../../../scripts/copy-natives.js win32-x64",
-        "__test": "jest",
-        "start": "node dist/index.js",
-        "precommit": "lint-staged"
-    },
-    "devDependencies": {
-        "lint-staged": "^7.2.0",
-        "nexe": "^3.3.7"
-    },
-    "dependencies": {
-        "@worker/generic": "1.39.7"
-    },
-    "peerDependencies": {
-        "@sofie-automation/blueprints-integration": "*"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "engines": {
-        "node": ">=14.18.0"
-    },
-    "lint-staged": {
-        "*.{js,css,json,md,scss}": [
-            "prettier"
-        ],
-        "*.{ts,tsx}": [
-            "eslint"
-        ]
-    }
+	"name": "@worker/app",
+	"version": "1.39.7",
+	"description": "Boilerplace",
+	"private": true,
+	"scripts": {
+		"build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.json",
+		"oldbuild-win32": "mkdir deploy & rimraf deploy/worker.exe  && nexe dist/index.js -t windows-x64-12.18.1 -o deploy/worker.exe && node scripts/copy-natives.js win32-x64",
+		"build-win32": "mkdir deploy & node ../../../scripts/build-win32.js worker.exe && node ../../../scripts/copy-natives.js win32-x64",
+		"__test": "jest",
+		"start": "node dist/index.js",
+		"precommit": "lint-staged"
+	},
+	"devDependencies": {
+		"lint-staged": "^7.2.0",
+		"nexe": "^3.3.7"
+	},
+	"dependencies": {
+		"@worker/generic": "1.39.7"
+	},
+	"peerDependencies": {},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier"
+		],
+		"*.{ts,tsx}": [
+			"eslint"
+		]
+	}
 }

--- a/apps/worker/app/package.json
+++ b/apps/worker/app/package.json
@@ -1,35 +1,35 @@
 {
-  "name": "@worker/app",
-  "version": "1.39.7",
-  "description": "Boilerplace",
-  "private": true,
-  "scripts": {
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "oldbuild-win32": "mkdir deploy & rimraf deploy/worker.exe  && nexe dist/index.js -t windows-x64-12.18.1 -o deploy/worker.exe && node scripts/copy-natives.js win32-x64",
-    "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js worker.exe && node ../../../scripts/copy-natives.js win32-x64",
-    "__test": "jest",
-    "start": "node dist/index.js",
-    "precommit": "lint-staged"
-  },
-  "devDependencies": {
-    "lint-staged": "^7.2.0",
-    "nexe": "^3.3.7"
-  },
-  "dependencies": {
-    "@worker/generic": "1.39.7"
-  },
-  "peerDependencies": {},
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
-    ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "name": "@worker/app",
+    "version": "1.39.7",
+    "description": "Boilerplace",
+    "private": true,
+    "scripts": {
+        "build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "oldbuild-win32": "mkdir deploy & rimraf deploy/worker.exe  && nexe dist/index.js -t windows-x64-12.18.1 -o deploy/worker.exe && node scripts/copy-natives.js win32-x64",
+        "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js worker.exe && node ../../../scripts/copy-natives.js win32-x64",
+        "__test": "jest",
+        "start": "node dist/index.js",
+        "precommit": "lint-staged"
+    },
+    "devDependencies": {
+        "lint-staged": "^7.2.0",
+        "nexe": "^3.3.7"
+    },
+    "dependencies": {
+        "@worker/generic": "1.39.7"
+    },
+    "peerDependencies": {},
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/apps/worker/app/package.json
+++ b/apps/worker/app/package.json
@@ -1,35 +1,35 @@
 {
-	"name": "@worker/app",
-	"version": "1.39.7",
-	"description": "Boilerplace",
-	"private": true,
-	"scripts": {
-		"build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"oldbuild-win32": "mkdir deploy & rimraf deploy/worker.exe  && nexe dist/index.js -t windows-x64-12.18.1 -o deploy/worker.exe && node scripts/copy-natives.js win32-x64",
-		"build-win32": "mkdir deploy & node ../../../scripts/build-win32.js worker.exe && node ../../../scripts/copy-natives.js win32-x64",
-		"__test": "jest",
-		"start": "node dist/index.js",
-		"precommit": "lint-staged"
-	},
-	"devDependencies": {
-		"lint-staged": "^7.2.0",
-		"nexe": "^3.3.7"
-	},
-	"dependencies": {
-		"@worker/generic": "1.39.7"
-	},
-	"peerDependencies": {},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@worker/app",
+  "version": "1.39.7",
+  "description": "Boilerplace",
+  "private": true,
+  "scripts": {
+    "build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "oldbuild-win32": "mkdir deploy & rimraf deploy/worker.exe  && nexe dist/index.js -t windows-x64-12.18.1 -o deploy/worker.exe && node scripts/copy-natives.js win32-x64",
+    "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js worker.exe && node ../../../scripts/copy-natives.js win32-x64",
+    "__test": "jest",
+    "start": "node dist/index.js",
+    "precommit": "lint-staged"
+  },
+  "devDependencies": {
+    "lint-staged": "^7.2.0",
+    "nexe": "^3.3.7"
+  },
+  "dependencies": {
+    "@worker/generic": "1.39.7"
+  },
+  "peerDependencies": {},
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/apps/worker/packages/generic/package.json
+++ b/apps/worker/packages/generic/package.json
@@ -1,35 +1,33 @@
 {
-    "name": "@worker/generic",
-    "version": "1.39.7",
-    "private": true,
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "scripts": {
-        "build": "rimraf dist && yarn build:main",
-        "build:main": "tsc -p tsconfig.json",
-        "__test": "jest",
-        "precommit": "lint-staged"
-    },
-    "peerDependencies": {
-        "@sofie-automation/blueprints-integration": "*"
-    },
-    "dependencies": {
-        "@sofie-package-manager/api": "1.39.2",
-        "@sofie-package-manager/worker": "1.39.7"
-    },
-    "devDependencies": {
-        "lint-staged": "^7.2.0"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "engines": {
-        "node": ">=14.18.0"
-    },
-    "lint-staged": {
-        "*.{js,css,json,md,scss}": [
-            "prettier"
-        ],
-        "*.{ts,tsx}": [
-            "eslint"
-        ]
-    }
+	"name": "@worker/generic",
+	"version": "1.39.7",
+	"private": true,
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"scripts": {
+		"build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.json",
+		"__test": "jest",
+		"precommit": "lint-staged"
+	},
+	"peerDependencies": {},
+	"dependencies": {
+		"@sofie-package-manager/api": "1.39.2",
+		"@sofie-package-manager/worker": "1.39.7"
+	},
+	"devDependencies": {
+		"lint-staged": "^7.2.0"
+	},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier"
+		],
+		"*.{ts,tsx}": [
+			"eslint"
+		]
+	}
 }

--- a/apps/worker/packages/generic/package.json
+++ b/apps/worker/packages/generic/package.json
@@ -1,33 +1,33 @@
 {
-	"name": "@worker/generic",
-	"version": "1.39.7",
-	"private": true,
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"scripts": {
-		"build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"__test": "jest",
-		"precommit": "lint-staged"
-	},
-	"peerDependencies": {},
-	"dependencies": {
-		"@sofie-package-manager/api": "1.39.2",
-		"@sofie-package-manager/worker": "1.39.7"
-	},
-	"devDependencies": {
-		"lint-staged": "^7.2.0"
-	},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@worker/generic",
+  "version": "1.39.7",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "__test": "jest",
+    "precommit": "lint-staged"
+  },
+  "peerDependencies": {},
+  "dependencies": {
+    "@sofie-package-manager/api": "1.39.2",
+    "@sofie-package-manager/worker": "1.39.7"
+  },
+  "devDependencies": {
+    "lint-staged": "^7.2.0"
+  },
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/apps/worker/packages/generic/package.json
+++ b/apps/worker/packages/generic/package.json
@@ -1,33 +1,33 @@
 {
-  "name": "@worker/generic",
-  "version": "1.39.7",
-  "private": true,
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "__test": "jest",
-    "precommit": "lint-staged"
-  },
-  "peerDependencies": {},
-  "dependencies": {
-    "@sofie-package-manager/api": "1.39.2",
-    "@sofie-package-manager/worker": "1.39.7"
-  },
-  "devDependencies": {
-    "lint-staged": "^7.2.0"
-  },
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
-    ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "name": "@worker/generic",
+    "version": "1.39.7",
+    "private": true,
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "scripts": {
+        "build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "__test": "jest",
+        "precommit": "lint-staged"
+    },
+    "peerDependencies": {},
+    "dependencies": {
+        "@sofie-package-manager/api": "1.39.2",
+        "@sofie-package-manager/worker": "1.39.7"
+    },
+    "devDependencies": {
+        "lint-staged": "^7.2.0"
+    },
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/apps/workforce/app/package.json
+++ b/apps/workforce/app/package.json
@@ -1,36 +1,34 @@
 {
-    "name": "@workforce/app",
-    "version": "1.39.2",
-    "description": "Boilerplace",
-    "private": true,
-    "scripts": {
-        "build": "rimraf dist && yarn build:main",
-        "build:main": "tsc -p tsconfig.json",
-        "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js workforce.exe && node ../../../scripts/copy-natives.js win32-x64",
-        "__test": "jest",
-        "start": "node dist/index.js",
-        "precommit": "lint-staged"
-    },
-    "devDependencies": {
-        "lint-staged": "^7.2.0",
-        "nexe": "^3.3.7"
-    },
-    "dependencies": {
-        "@workforce/generic": "1.39.2"
-    },
-    "peerDependencies": {
-        "@sofie-automation/blueprints-integration": "*"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "engines": {
-        "node": ">=14.18.0"
-    },
-    "lint-staged": {
-        "*.{js,css,json,md,scss}": [
-            "prettier"
-        ],
-        "*.{ts,tsx}": [
-            "eslint"
-        ]
-    }
+	"name": "@workforce/app",
+	"version": "1.39.2",
+	"description": "Boilerplace",
+	"private": true,
+	"scripts": {
+		"build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.json",
+		"build-win32": "mkdir deploy & node ../../../scripts/build-win32.js workforce.exe && node ../../../scripts/copy-natives.js win32-x64",
+		"__test": "jest",
+		"start": "node dist/index.js",
+		"precommit": "lint-staged"
+	},
+	"devDependencies": {
+		"lint-staged": "^7.2.0",
+		"nexe": "^3.3.7"
+	},
+	"dependencies": {
+		"@workforce/generic": "1.39.2"
+	},
+	"peerDependencies": {},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier"
+		],
+		"*.{ts,tsx}": [
+			"eslint"
+		]
+	}
 }

--- a/apps/workforce/app/package.json
+++ b/apps/workforce/app/package.json
@@ -1,34 +1,34 @@
 {
-  "name": "@workforce/app",
-  "version": "1.39.2",
-  "description": "Boilerplace",
-  "private": true,
-  "scripts": {
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js workforce.exe && node ../../../scripts/copy-natives.js win32-x64",
-    "__test": "jest",
-    "start": "node dist/index.js",
-    "precommit": "lint-staged"
-  },
-  "devDependencies": {
-    "lint-staged": "^7.2.0",
-    "nexe": "^3.3.7"
-  },
-  "dependencies": {
-    "@workforce/generic": "1.39.2"
-  },
-  "peerDependencies": {},
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
-    ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "name": "@workforce/app",
+    "version": "1.39.2",
+    "description": "Boilerplace",
+    "private": true,
+    "scripts": {
+        "build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js workforce.exe && node ../../../scripts/copy-natives.js win32-x64",
+        "__test": "jest",
+        "start": "node dist/index.js",
+        "precommit": "lint-staged"
+    },
+    "devDependencies": {
+        "lint-staged": "^7.2.0",
+        "nexe": "^3.3.7"
+    },
+    "dependencies": {
+        "@workforce/generic": "1.39.2"
+    },
+    "peerDependencies": {},
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/apps/workforce/app/package.json
+++ b/apps/workforce/app/package.json
@@ -1,34 +1,34 @@
 {
-	"name": "@workforce/app",
-	"version": "1.39.2",
-	"description": "Boilerplace",
-	"private": true,
-	"scripts": {
-		"build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"build-win32": "mkdir deploy & node ../../../scripts/build-win32.js workforce.exe && node ../../../scripts/copy-natives.js win32-x64",
-		"__test": "jest",
-		"start": "node dist/index.js",
-		"precommit": "lint-staged"
-	},
-	"devDependencies": {
-		"lint-staged": "^7.2.0",
-		"nexe": "^3.3.7"
-	},
-	"dependencies": {
-		"@workforce/generic": "1.39.2"
-	},
-	"peerDependencies": {},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@workforce/app",
+  "version": "1.39.2",
+  "description": "Boilerplace",
+  "private": true,
+  "scripts": {
+    "build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "build-win32": "mkdir deploy & node ../../../scripts/build-win32.js workforce.exe && node ../../../scripts/copy-natives.js win32-x64",
+    "__test": "jest",
+    "start": "node dist/index.js",
+    "precommit": "lint-staged"
+  },
+  "devDependencies": {
+    "lint-staged": "^7.2.0",
+    "nexe": "^3.3.7"
+  },
+  "dependencies": {
+    "@workforce/generic": "1.39.2"
+  },
+  "peerDependencies": {},
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/apps/workforce/packages/generic/package.json
+++ b/apps/workforce/packages/generic/package.json
@@ -1,33 +1,33 @@
 {
-	"name": "@workforce/generic",
-	"version": "1.39.2",
-	"private": true,
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"scripts": {
-		"build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"__test": "jest",
-		"precommit": "lint-staged"
-	},
-	"peerDependencies": {},
-	"dependencies": {
-		"@sofie-package-manager/api": "1.39.2",
-		"@sofie-package-manager/workforce": "1.39.2"
-	},
-	"devDependencies": {
-		"lint-staged": "^7.2.0"
-	},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@workforce/generic",
+  "version": "1.39.2",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "__test": "jest",
+    "precommit": "lint-staged"
+  },
+  "peerDependencies": {},
+  "dependencies": {
+    "@sofie-package-manager/api": "1.39.2",
+    "@sofie-package-manager/workforce": "1.39.2"
+  },
+  "devDependencies": {
+    "lint-staged": "^7.2.0"
+  },
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/apps/workforce/packages/generic/package.json
+++ b/apps/workforce/packages/generic/package.json
@@ -1,33 +1,33 @@
 {
-  "name": "@workforce/generic",
-  "version": "1.39.2",
-  "private": true,
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "__test": "jest",
-    "precommit": "lint-staged"
-  },
-  "peerDependencies": {},
-  "dependencies": {
-    "@sofie-package-manager/api": "1.39.2",
-    "@sofie-package-manager/workforce": "1.39.2"
-  },
-  "devDependencies": {
-    "lint-staged": "^7.2.0"
-  },
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
-    ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "name": "@workforce/generic",
+    "version": "1.39.2",
+    "private": true,
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "scripts": {
+        "build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "__test": "jest",
+        "precommit": "lint-staged"
+    },
+    "peerDependencies": {},
+    "dependencies": {
+        "@sofie-package-manager/api": "1.39.2",
+        "@sofie-package-manager/workforce": "1.39.2"
+    },
+    "devDependencies": {
+        "lint-staged": "^7.2.0"
+    },
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/apps/workforce/packages/generic/package.json
+++ b/apps/workforce/packages/generic/package.json
@@ -1,35 +1,33 @@
 {
-    "name": "@workforce/generic",
-    "version": "1.39.2",
-    "private": true,
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "scripts": {
-        "build": "rimraf dist && yarn build:main",
-        "build:main": "tsc -p tsconfig.json",
-        "__test": "jest",
-        "precommit": "lint-staged"
-    },
-    "peerDependencies": {
-        "@sofie-automation/blueprints-integration": "*"
-    },
-    "dependencies": {
-        "@sofie-package-manager/api": "1.39.2",
-        "@sofie-package-manager/workforce": "1.39.2"
-    },
-    "devDependencies": {
-        "lint-staged": "^7.2.0"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "engines": {
-        "node": ">=14.18.0"
-    },
-    "lint-staged": {
-        "*.{js,css,json,md,scss}": [
-            "prettier"
-        ],
-        "*.{ts,tsx}": [
-            "eslint"
-        ]
-    }
+	"name": "@workforce/generic",
+	"version": "1.39.2",
+	"private": true,
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"scripts": {
+		"build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.json",
+		"__test": "jest",
+		"precommit": "lint-staged"
+	},
+	"peerDependencies": {},
+	"dependencies": {
+		"@sofie-package-manager/api": "1.39.2",
+		"@sofie-package-manager/workforce": "1.39.2"
+	},
+	"devDependencies": {
+		"lint-staged": "^7.2.0"
+	},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier"
+		],
+		"*.{ts,tsx}": [
+			"eslint"
+		]
+	}
 }

--- a/commonPackage.json
+++ b/commonPackage.json
@@ -1,24 +1,18 @@
 {
-  "description": "The properties of this file are automatically copied to all packages' package.json files",
-  "scripts": {
-    "precommit": "lint-staged"
-  },
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "devDependencies": {
-    "lint-staged": "^7.2.0"
-  },
-  "peerDependencies": {
-    "@sofie-automation/blueprints-integration": "*"
-  },
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
-    ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+	"description": "The properties of this file are automatically copied to all packages' package.json files",
+	"scripts": {
+		"precommit": "lint-staged"
+	},
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"devDependencies": {
+		"lint-staged": "^7.2.0"
+	},
+	"peerDependencies": {},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": ["prettier"],
+		"*.{ts,tsx}": ["eslint"]
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,78 +1,78 @@
 {
-  "name": "package-manager-monorepo",
-  "version": "1.0.0",
-  "repository": "https://github.com/nrkno/tv-automation-package-manager",
-  "private": true,
-  "workspaces": [
-    "shared/**",
-    "apps/**",
-    "tests/**"
-  ],
-  "scripts": {
-    "ci": "yarn install && yarn build && yarn lint && yarn test",
-    "release:bump-release": "lerna version --conventional-commits --conventional-graduate --exact --no-push",
-    "release:bump-prerelease": "lerna version --conventional-commits --conventional-prerelease --exact --no-push",
-    "set-version": "lerna version --exact --no-changelog --no-git-tag-version --no-push --yes",
-    "setup": "lerna bootstrap",
-    "reset": "node scripts/reset.js",
-    "build": "lerna run build --stream",
-    "build:changed": "lerna run build --since head --exclude-dependents --stream",
-    "lint": "lerna exec --parallel --no-bail -- eslint . --ext .ts,.tsx",
-    "lintfix": "yarn lint --fix",
-    "lint:changed": "lerna exec --since origin/master --include-dependents -- eslint . --ext .js,.jsx,.ts,.tsx",
-    "test": "lerna run test --stream",
-    "test:ci": "lerna run test --stream --ignore=@tests/**",
-    "test:changed": "lerna run --since origin/master --include-dependents test",
-    "test:update": "lerna run test -- -u",
-    "test:update:changed": "lerna run --since origin/master --include-dependents test -- -u",
-    "typecheck": "lerna exec -- tsc --noEmit",
-    "typecheck:changed": "lerna exec --since origin/master --include-dependents -- tsc --noEmit",
-    "build-win32": "node scripts/prepare-for-build32.js && lerna run build-win32 --stream && node scripts/cleanup-after-build32.js",
-    "gather-built": "node scripts/gather-all-built.js",
-    "sign-executables": "node scripts/sign-executables.js",
-    "start:http-server": "lerna run start --stream --scope @http-server/app",
-    "start:workforce": "lerna run start --stream --scope @workforce/app",
-    "start:package-manager": "lerna run start --stream --scope @package-manager/app",
-    "start:worker": "lerna run start --stream --scope @worker/app",
-    "start:single-app": "lerna run start --stream --scope @single-app/app",
-    "postinstall": "node scripts/update-packages.js",
-    "do:build-win32": "yarn install && yarn build && yarn build-win32 && yarn gather-built && yarn sign-executables"
-  },
-  "devDependencies": {
-    "@sofie-automation/code-standard-preset": "^2.0.2",
-    "@types/jest": "^26.0.20",
-    "deep-extend": "^0.6.0",
-    "eslint": "7.19.0",
-    "eslint-plugin-jest": "^22.0.0",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^3.3.1",
-    "eslint-config-prettier": "^8.5.0",
-    "find": "^0.3.0",
-    "fs-extra": "^9.1.0",
-    "glob": "^7.1.6",
-    "husky": "^4.3.8",
-    "jest": "^26.6.3",
-    "lerna": "^3.22.1",
-    "lint-staged": "^10.5.3",
-    "mkdirp": "^1.0.4",
-    "prettier": "^2.2.1",
-    "rimraf": "^3.0.2",
-    "trash": "^7.1.0",
-    "ts-jest": "^26.5.0",
-    "typescript": "^4.5.0"
-  },
-  "engines": {
-    "node": ">=12.11.0"
-  },
-  "dependencies": {
-    "@sofie-automation/server-core-integration": "1.44.1"
-  },
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "husky": {
-    "hooks": {
-      "pre-commit": [
-        "node scripts/update-packages.js && lerna run --concurrency 1 --stream precommit --since HEAD --exclude-dependents"
-      ]
+    "name": "package-manager-monorepo",
+    "version": "1.0.0",
+    "repository": "https://github.com/nrkno/tv-automation-package-manager",
+    "private": true,
+    "workspaces": [
+        "shared/**",
+        "apps/**",
+        "tests/**"
+    ],
+    "scripts": {
+        "ci": "yarn install && yarn build && yarn lint && yarn test",
+        "release:bump-release": "lerna version --conventional-commits --conventional-graduate --exact --no-push",
+        "release:bump-prerelease": "lerna version --conventional-commits --conventional-prerelease --exact --no-push",
+        "set-version": "lerna version --exact --no-changelog --no-git-tag-version --no-push --yes",
+        "setup": "lerna bootstrap",
+        "reset": "node scripts/reset.js",
+        "build": "lerna run build --stream",
+        "build:changed": "lerna run build --since head --exclude-dependents --stream",
+        "lint": "lerna exec --parallel --no-bail -- eslint . --ext .ts,.tsx",
+        "lintfix": "yarn lint --fix",
+        "lint:changed": "lerna exec --since origin/master --include-dependents -- eslint . --ext .js,.jsx,.ts,.tsx",
+        "test": "lerna run test --stream",
+        "test:ci": "lerna run test --stream --ignore=@tests/**",
+        "test:changed": "lerna run --since origin/master --include-dependents test",
+        "test:update": "lerna run test -- -u",
+        "test:update:changed": "lerna run --since origin/master --include-dependents test -- -u",
+        "typecheck": "lerna exec -- tsc --noEmit",
+        "typecheck:changed": "lerna exec --since origin/master --include-dependents -- tsc --noEmit",
+        "build-win32": "node scripts/prepare-for-build32.js && lerna run build-win32 --stream && node scripts/cleanup-after-build32.js",
+        "gather-built": "node scripts/gather-all-built.js",
+        "sign-executables": "node scripts/sign-executables.js",
+        "start:http-server": "lerna run start --stream --scope @http-server/app",
+        "start:workforce": "lerna run start --stream --scope @workforce/app",
+        "start:package-manager": "lerna run start --stream --scope @package-manager/app",
+        "start:worker": "lerna run start --stream --scope @worker/app",
+        "start:single-app": "lerna run start --stream --scope @single-app/app",
+        "postinstall": "node scripts/update-packages.js",
+        "do:build-win32": "yarn install && yarn build && yarn build-win32 && yarn gather-built && yarn sign-executables"
+    },
+    "devDependencies": {
+        "@sofie-automation/code-standard-preset": "^2.0.2",
+        "@types/jest": "^26.0.20",
+        "deep-extend": "^0.6.0",
+        "eslint": "7.19.0",
+        "eslint-plugin-jest": "^22.0.0",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-prettier": "^3.3.1",
+        "eslint-config-prettier": "^8.5.0",
+        "find": "^0.3.0",
+        "fs-extra": "^9.1.0",
+        "glob": "^7.1.6",
+        "husky": "^4.3.8",
+        "jest": "^26.6.3",
+        "lerna": "^3.22.1",
+        "lint-staged": "^10.5.3",
+        "mkdirp": "^1.0.4",
+        "prettier": "^2.2.1",
+        "rimraf": "^3.0.2",
+        "trash": "^7.1.0",
+        "ts-jest": "^26.5.0",
+        "typescript": "^4.5.0"
+    },
+    "engines": {
+        "node": ">=12.11.0"
+    },
+    "dependencies": {
+        "@sofie-automation/server-core-integration": "1.44.1"
+    },
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "husky": {
+        "hooks": {
+            "pre-commit": [
+                "node scripts/update-packages.js && lerna run --concurrency 1 --stream precommit --since HEAD --exclude-dependents"
+            ]
+        }
     }
-  }
 }

--- a/package.json
+++ b/package.json
@@ -1,78 +1,78 @@
 {
-	"name": "package-manager-monorepo",
-	"version": "1.0.0",
-	"repository": "https://github.com/nrkno/tv-automation-package-manager",
-	"private": true,
-	"workspaces": [
-		"shared/**",
-		"apps/**",
-		"tests/**"
-	],
-	"scripts": {
-		"ci": "yarn install && yarn build && yarn lint && yarn test",
-		"release:bump-release": "lerna version --conventional-commits --conventional-graduate --exact --no-push",
-		"release:bump-prerelease": "lerna version --conventional-commits --conventional-prerelease --exact --no-push",
-		"set-version": "lerna version --exact --no-changelog --no-git-tag-version --no-push --yes",
-		"setup": "lerna bootstrap",
-		"reset": "node scripts/reset.js",
-		"build": "lerna run build --stream",
-		"build:changed": "lerna run build --since head --exclude-dependents --stream",
-		"lint": "lerna exec --parallel --no-bail -- eslint . --ext .ts,.tsx",
-		"lintfix": "yarn lint --fix",
-		"lint:changed": "lerna exec --since origin/master --include-dependents -- eslint . --ext .js,.jsx,.ts,.tsx",
-		"test": "lerna run test --stream",
-		"test:ci": "lerna run test --stream --ignore=@tests/**",
-		"test:changed": "lerna run --since origin/master --include-dependents test",
-		"test:update": "lerna run test -- -u",
-		"test:update:changed": "lerna run --since origin/master --include-dependents test -- -u",
-		"typecheck": "lerna exec -- tsc --noEmit",
-		"typecheck:changed": "lerna exec --since origin/master --include-dependents -- tsc --noEmit",
-		"build-win32": "node scripts/prepare-for-build32.js && lerna run build-win32 --stream && node scripts/cleanup-after-build32.js",
-		"gather-built": "node scripts/gather-all-built.js",
-		"sign-executables": "node scripts/sign-executables.js",
-		"start:http-server": "lerna run start --stream --scope @http-server/app",
-		"start:workforce": "lerna run start --stream --scope @workforce/app",
-		"start:package-manager": "lerna run start --stream --scope @package-manager/app",
-		"start:worker": "lerna run start --stream --scope @worker/app",
-		"start:single-app": "lerna run start --stream --scope @single-app/app",
-		"postinstall": "node scripts/update-packages.js",
-		"do:build-win32": "yarn install && yarn build && yarn build-win32 && yarn gather-built && yarn sign-executables"
-	},
-	"devDependencies": {
-		"@sofie-automation/code-standard-preset": "^2.0.2",
-		"@types/jest": "^26.0.20",
-		"deep-extend": "^0.6.0",
-		"eslint": "7.19.0",
-		"eslint-plugin-jest": "^22.0.0",
-		"eslint-plugin-node": "^11.1.0",
-		"eslint-plugin-prettier": "^3.3.1",
-		"eslint-config-prettier": "^8.5.0",
-		"find": "^0.3.0",
-		"fs-extra": "^9.1.0",
-		"glob": "^7.1.6",
-		"husky": "^4.3.8",
-		"jest": "^26.6.3",
-		"lerna": "^3.22.1",
-		"lint-staged": "^10.5.3",
-		"mkdirp": "^1.0.4",
-		"prettier": "^2.2.1",
-		"rimraf": "^3.0.2",
-		"trash": "^7.1.0",
-		"ts-jest": "^26.5.0",
-		"typescript": "^4.5.0"
-	},
-	"engines": {
-		"node": ">=12.11.0"
-	},
-	"dependencies": {
-		"@sofie-automation/server-core-integration": "1.44.1"
-	},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"husky": {
-		"hooks": {
-			"pre-commit": [
-				"node scripts/update-packages.js && lerna run --concurrency 1 --stream precommit --since HEAD --exclude-dependents"
-			]
-		}
-	}
+  "name": "package-manager-monorepo",
+  "version": "1.0.0",
+  "repository": "https://github.com/nrkno/tv-automation-package-manager",
+  "private": true,
+  "workspaces": [
+    "shared/**",
+    "apps/**",
+    "tests/**"
+  ],
+  "scripts": {
+    "ci": "yarn install && yarn build && yarn lint && yarn test",
+    "release:bump-release": "lerna version --conventional-commits --conventional-graduate --exact --no-push",
+    "release:bump-prerelease": "lerna version --conventional-commits --conventional-prerelease --exact --no-push",
+    "set-version": "lerna version --exact --no-changelog --no-git-tag-version --no-push --yes",
+    "setup": "lerna bootstrap",
+    "reset": "node scripts/reset.js",
+    "build": "lerna run build --stream",
+    "build:changed": "lerna run build --since head --exclude-dependents --stream",
+    "lint": "lerna exec --parallel --no-bail -- eslint . --ext .ts,.tsx",
+    "lintfix": "yarn lint --fix",
+    "lint:changed": "lerna exec --since origin/master --include-dependents -- eslint . --ext .js,.jsx,.ts,.tsx",
+    "test": "lerna run test --stream",
+    "test:ci": "lerna run test --stream --ignore=@tests/**",
+    "test:changed": "lerna run --since origin/master --include-dependents test",
+    "test:update": "lerna run test -- -u",
+    "test:update:changed": "lerna run --since origin/master --include-dependents test -- -u",
+    "typecheck": "lerna exec -- tsc --noEmit",
+    "typecheck:changed": "lerna exec --since origin/master --include-dependents -- tsc --noEmit",
+    "build-win32": "node scripts/prepare-for-build32.js && lerna run build-win32 --stream && node scripts/cleanup-after-build32.js",
+    "gather-built": "node scripts/gather-all-built.js",
+    "sign-executables": "node scripts/sign-executables.js",
+    "start:http-server": "lerna run start --stream --scope @http-server/app",
+    "start:workforce": "lerna run start --stream --scope @workforce/app",
+    "start:package-manager": "lerna run start --stream --scope @package-manager/app",
+    "start:worker": "lerna run start --stream --scope @worker/app",
+    "start:single-app": "lerna run start --stream --scope @single-app/app",
+    "postinstall": "node scripts/update-packages.js",
+    "do:build-win32": "yarn install && yarn build && yarn build-win32 && yarn gather-built && yarn sign-executables"
+  },
+  "devDependencies": {
+    "@sofie-automation/code-standard-preset": "^2.0.2",
+    "@types/jest": "^26.0.20",
+    "deep-extend": "^0.6.0",
+    "eslint": "7.19.0",
+    "eslint-plugin-jest": "^22.0.0",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^3.3.1",
+    "eslint-config-prettier": "^8.5.0",
+    "find": "^0.3.0",
+    "fs-extra": "^9.1.0",
+    "glob": "^7.1.6",
+    "husky": "^4.3.8",
+    "jest": "^26.6.3",
+    "lerna": "^3.22.1",
+    "lint-staged": "^10.5.3",
+    "mkdirp": "^1.0.4",
+    "prettier": "^2.2.1",
+    "rimraf": "^3.0.2",
+    "trash": "^7.1.0",
+    "ts-jest": "^26.5.0",
+    "typescript": "^4.5.0"
+  },
+  "engines": {
+    "node": ">=12.11.0"
+  },
+  "dependencies": {
+    "@sofie-automation/server-core-integration": "1.44.1"
+  },
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "husky": {
+    "hooks": {
+      "pre-commit": [
+        "node scripts/update-packages.js && lerna run --concurrency 1 --stream precommit --since HEAD --exclude-dependents"
+      ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,79 +1,79 @@
 {
-    "name": "package-manager-monorepo",
-    "version": "1.0.0",
-    "repository": "https://github.com/nrkno/tv-automation-package-manager",
-    "private": true,
-    "workspaces": [
-        "shared/**",
-        "apps/**",
-        "tests/**"
-    ],
-    "scripts": {
-        "ci": "yarn install && yarn build && yarn lint && yarn test",
-        "release:bump-release": "lerna version --conventional-commits --conventional-graduate --exact --no-push",
-        "release:bump-prerelease": "lerna version --conventional-commits --conventional-prerelease --exact --no-push",
-        "set-version": "lerna version --exact --no-changelog --no-git-tag-version --no-push --yes",
-        "setup": "lerna bootstrap",
-        "reset": "node scripts/reset.js",
-        "build": "lerna run build --stream",
-        "build:changed": "lerna run build --since head --exclude-dependents --stream",
-        "lint": "lerna exec --parallel --no-bail -- eslint . --ext .ts,.tsx",
-        "lintfix": "yarn lint --fix",
-        "lint:changed": "lerna exec --since origin/master --include-dependents -- eslint . --ext .js,.jsx,.ts,.tsx",
-        "test": "lerna run test --stream",
-        "test:ci": "lerna run test --stream --ignore=@tests/**",
-        "test:changed": "lerna run --since origin/master --include-dependents test",
-        "test:update": "lerna run test -- -u",
-        "test:update:changed": "lerna run --since origin/master --include-dependents test -- -u",
-        "typecheck": "lerna exec -- tsc --noEmit",
-        "typecheck:changed": "lerna exec --since origin/master --include-dependents -- tsc --noEmit",
-        "build-win32": "node scripts/prepare-for-build32.js && lerna run build-win32 --stream && node scripts/cleanup-after-build32.js",
-        "gather-built": "node scripts/gather-all-built.js",
-        "sign-executables": "node scripts/sign-executables.js",
-        "start:http-server": "lerna run start --stream --scope @http-server/app",
-        "start:workforce": "lerna run start --stream --scope @workforce/app",
-        "start:package-manager": "lerna run start --stream --scope @package-manager/app",
-        "start:worker": "lerna run start --stream --scope @worker/app",
-        "start:single-app": "lerna run start --stream --scope @single-app/app",
-        "postinstall": "node scripts/update-packages.js",
-        "do:build-win32": "yarn install && yarn build && yarn build-win32 && yarn gather-built && yarn sign-executables"
-    },
-    "devDependencies": {
-        "@sofie-automation/code-standard-preset": "^2.0.2",
-        "@types/jest": "^26.0.20",
-        "deep-extend": "^0.6.0",
-        "eslint": "7.19.0",
-        "eslint-plugin-jest": "^22.0.0",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prettier": "^3.3.1",
-        "eslint-config-prettier": "^8.5.0",
-        "find": "^0.3.0",
-        "fs-extra": "^9.1.0",
-        "glob": "^7.1.6",
-        "husky": "^4.3.8",
-        "jest": "^26.6.3",
-        "lerna": "^3.22.1",
-        "lint-staged": "^10.5.3",
-        "mkdirp": "^1.0.4",
-        "prettier": "^2.2.1",
-        "rimraf": "^3.0.2",
-        "trash": "^7.1.0",
-        "ts-jest": "^26.5.0",
-        "typescript": "^4.5.0"
-    },
-    "engines": {
-        "node": ">=12.11.0"
-    },
-    "dependencies": {
-        "@sofie-automation/blueprints-integration": "1.38.0-nightly-release38-20211208-162831-102085a.0",
-        "@sofie-automation/server-core-integration": "1.38.0-nightly-release38-20211208-162831-102085a.0"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "husky": {
-        "hooks": {
-            "pre-commit": [
-                "node scripts/update-packages.js && lerna run --concurrency 1 --stream precommit --since HEAD --exclude-dependents"
-            ]
-        }
-    }
+	"name": "package-manager-monorepo",
+	"version": "1.0.0",
+	"repository": "https://github.com/nrkno/tv-automation-package-manager",
+	"private": true,
+	"workspaces": [
+		"shared/**",
+		"apps/**",
+		"tests/**"
+	],
+	"scripts": {
+		"ci": "yarn install && yarn build && yarn lint && yarn test",
+		"release:bump-release": "lerna version --conventional-commits --conventional-graduate --exact --no-push",
+		"release:bump-prerelease": "lerna version --conventional-commits --conventional-prerelease --exact --no-push",
+		"set-version": "lerna version --exact --no-changelog --no-git-tag-version --no-push --yes",
+		"setup": "lerna bootstrap",
+		"reset": "node scripts/reset.js",
+		"build": "lerna run build --stream",
+		"build:changed": "lerna run build --since head --exclude-dependents --stream",
+		"lint": "lerna exec --parallel --no-bail -- eslint . --ext .ts,.tsx",
+		"lintfix": "yarn lint --fix",
+		"lint:changed": "lerna exec --since origin/master --include-dependents -- eslint . --ext .js,.jsx,.ts,.tsx",
+		"test": "lerna run test --stream",
+		"test:ci": "lerna run test --stream --ignore=@tests/**",
+		"test:changed": "lerna run --since origin/master --include-dependents test",
+		"test:update": "lerna run test -- -u",
+		"test:update:changed": "lerna run --since origin/master --include-dependents test -- -u",
+		"typecheck": "lerna exec -- tsc --noEmit",
+		"typecheck:changed": "lerna exec --since origin/master --include-dependents -- tsc --noEmit",
+		"build-win32": "node scripts/prepare-for-build32.js && lerna run build-win32 --stream && node scripts/cleanup-after-build32.js",
+		"gather-built": "node scripts/gather-all-built.js",
+		"sign-executables": "node scripts/sign-executables.js",
+		"start:http-server": "lerna run start --stream --scope @http-server/app",
+		"start:workforce": "lerna run start --stream --scope @workforce/app",
+		"start:package-manager": "lerna run start --stream --scope @package-manager/app",
+		"start:worker": "lerna run start --stream --scope @worker/app",
+		"start:single-app": "lerna run start --stream --scope @single-app/app",
+		"postinstall": "node scripts/update-packages.js",
+		"do:build-win32": "yarn install && yarn build && yarn build-win32 && yarn gather-built && yarn sign-executables"
+	},
+	"devDependencies": {
+		"@sofie-automation/code-standard-preset": "^2.0.2",
+		"@types/jest": "^26.0.20",
+		"deep-extend": "^0.6.0",
+		"eslint": "7.19.0",
+		"eslint-plugin-jest": "^22.0.0",
+		"eslint-plugin-node": "^11.1.0",
+		"eslint-plugin-prettier": "^3.3.1",
+		"eslint-config-prettier": "^8.5.0",
+		"find": "^0.3.0",
+		"fs-extra": "^9.1.0",
+		"glob": "^7.1.6",
+		"husky": "^4.3.8",
+		"jest": "^26.6.3",
+		"lerna": "^3.22.1",
+		"lint-staged": "^10.5.3",
+		"mkdirp": "^1.0.4",
+		"prettier": "^2.2.1",
+		"rimraf": "^3.0.2",
+		"trash": "^7.1.0",
+		"ts-jest": "^26.5.0",
+		"typescript": "^4.5.0"
+	},
+	"engines": {
+		"node": ">=12.11.0"
+	},
+	"dependencies": {
+		"@sofie-automation/blueprints-integration": "1.44.1",
+		"@sofie-automation/server-core-integration": "1.44.1"
+	},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"husky": {
+		"hooks": {
+			"pre-commit": [
+				"node scripts/update-packages.js && lerna run --concurrency 1 --stream precommit --since HEAD --exclude-dependents"
+			]
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
 		"node": ">=12.11.0"
 	},
 	"dependencies": {
-		"@sofie-automation/blueprints-integration": "1.44.1",
 		"@sofie-automation/server-core-integration": "1.44.1"
 	},
 	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",

--- a/shared/packages/api/package.json
+++ b/shared/packages/api/package.json
@@ -1,40 +1,40 @@
 {
-	"name": "@sofie-package-manager/api",
-	"version": "1.39.2",
-	"main": "dist/index",
-	"types": "dist/index",
-	"files": [
-		"dist"
-	],
-	"license": "MIT",
-	"scripts": {
-		"build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"test": "jest",
-		"precommit": "lint-staged"
-	},
-	"peerDependencies": {},
-	"devDependencies": {
-		"@types/winston": "^2.3.9",
-		"@types/ws": "^7.4.0",
-		"lint-staged": "^7.2.0"
-	},
-	"dependencies": {
-		"underscore": "^1.12.0",
-		"winston": "^3.5.1",
-		"ws": "^7.4.3",
-		"yargs": "^16.2.0"
-	},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@sofie-package-manager/api",
+  "version": "1.39.2",
+  "main": "dist/index",
+  "types": "dist/index",
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "scripts": {
+    "build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "test": "jest",
+    "precommit": "lint-staged"
+  },
+  "peerDependencies": {},
+  "devDependencies": {
+    "@types/winston": "^2.3.9",
+    "@types/ws": "^7.4.0",
+    "lint-staged": "^7.2.0"
+  },
+  "dependencies": {
+    "underscore": "^1.12.0",
+    "winston": "^3.5.1",
+    "ws": "^7.4.3",
+    "yargs": "^16.2.0"
+  },
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/shared/packages/api/package.json
+++ b/shared/packages/api/package.json
@@ -1,40 +1,40 @@
 {
-  "name": "@sofie-package-manager/api",
-  "version": "1.39.2",
-  "main": "dist/index",
-  "types": "dist/index",
-  "files": [
-    "dist"
-  ],
-  "license": "MIT",
-  "scripts": {
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "test": "jest",
-    "precommit": "lint-staged"
-  },
-  "peerDependencies": {},
-  "devDependencies": {
-    "@types/winston": "^2.3.9",
-    "@types/ws": "^7.4.0",
-    "lint-staged": "^7.2.0"
-  },
-  "dependencies": {
-    "underscore": "^1.12.0",
-    "winston": "^3.5.1",
-    "ws": "^7.4.3",
-    "yargs": "^16.2.0"
-  },
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
+    "name": "@sofie-package-manager/api",
+    "version": "1.39.2",
+    "main": "dist/index",
+    "types": "dist/index",
+    "files": [
+        "dist"
     ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "license": "MIT",
+    "scripts": {
+        "build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "test": "jest",
+        "precommit": "lint-staged"
+    },
+    "peerDependencies": {},
+    "devDependencies": {
+        "@types/winston": "^2.3.9",
+        "@types/ws": "^7.4.0",
+        "lint-staged": "^7.2.0"
+    },
+    "dependencies": {
+        "underscore": "^1.12.0",
+        "winston": "^3.5.1",
+        "ws": "^7.4.3",
+        "yargs": "^16.2.0"
+    },
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/shared/packages/api/package.json
+++ b/shared/packages/api/package.json
@@ -1,42 +1,40 @@
 {
-    "name": "@sofie-package-manager/api",
-    "version": "1.39.2",
-    "main": "dist/index",
-    "types": "dist/index",
-    "files": [
-        "dist"
-    ],
-    "license": "MIT",
-    "scripts": {
-        "build": "rimraf dist && yarn build:main",
-        "build:main": "tsc -p tsconfig.json",
-        "test": "jest",
-        "precommit": "lint-staged"
-    },
-    "peerDependencies": {
-        "@sofie-automation/blueprints-integration": "*"
-    },
-    "devDependencies": {
-        "@types/winston": "^2.3.9",
-        "@types/ws": "^7.4.0",
-        "lint-staged": "^7.2.0"
-    },
-    "dependencies": {
-        "underscore": "^1.12.0",
-        "winston": "^3.5.1",
-        "ws": "^7.4.3",
-        "yargs": "^16.2.0"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "engines": {
-        "node": ">=14.18.0"
-    },
-    "lint-staged": {
-        "*.{js,css,json,md,scss}": [
-            "prettier"
-        ],
-        "*.{ts,tsx}": [
-            "eslint"
-        ]
-    }
+	"name": "@sofie-package-manager/api",
+	"version": "1.39.2",
+	"main": "dist/index",
+	"types": "dist/index",
+	"files": [
+		"dist"
+	],
+	"license": "MIT",
+	"scripts": {
+		"build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.json",
+		"test": "jest",
+		"precommit": "lint-staged"
+	},
+	"peerDependencies": {},
+	"devDependencies": {
+		"@types/winston": "^2.3.9",
+		"@types/ws": "^7.4.0",
+		"lint-staged": "^7.2.0"
+	},
+	"dependencies": {
+		"underscore": "^1.12.0",
+		"winston": "^3.5.1",
+		"ws": "^7.4.3",
+		"yargs": "^16.2.0"
+	},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier"
+		],
+		"*.{ts,tsx}": [
+			"eslint"
+		]
+	}
 }

--- a/shared/packages/api/src/expectationApi.ts
+++ b/shared/packages/api/src/expectationApi.ts
@@ -1,4 +1,5 @@
-import { ExpectedPackageStatusAPI } from '@sofie-automation/blueprints-integration'
+// eslint-disable-next-line node/no-extraneous-import
+import { ExpectedPackageStatusAPI } from '@sofie-automation/shared-lib/dist/package-manager/package'
 import { AccessorOnPackage, PackageContainerOnPackage } from './inputApi'
 
 /*

--- a/shared/packages/api/src/inputApi.ts
+++ b/shared/packages/api/src/inputApi.ts
@@ -1,4 +1,6 @@
-import * as BI from '@sofie-automation/blueprints-integration'
+// eslint-disable-next-line node/no-extraneous-import
+import { StatusCode as SofieStatusCode } from '@sofie-automation/shared-lib/dist/lib/status'
+
 // import { assertTrue, EnumExtends, assertEnumValuesExtends } from './lib'
 /* eslint-disable @typescript-eslint/no-namespace */
 
@@ -13,8 +15,8 @@ import * as BI from '@sofie-automation/blueprints-integration'
 	later to add it into blueprints-integration.
 */
 
-export type StatusCode = BI.StatusCode
-export const StatusCode = BI.StatusCode
+export type StatusCode = SofieStatusCode
+export const StatusCode = SofieStatusCode
 
 /**
  * An ExpectedPackage is sent from Core to the Package Manager, to signal that a Package (ie a Media file) should be copied to a playout-device.

--- a/shared/packages/api/src/methods.ts
+++ b/shared/packages/api/src/methods.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-import { ExpectedPackageStatusAPI } from '@sofie-automation/blueprints-integration'
+// eslint-disable-next-line node/no-extraneous-import
+import { ExpectedPackageStatusAPI } from '@sofie-automation/shared-lib/dist/package-manager/package'
 import { Expectation } from './expectationApi'
 import { PackageContainerExpectation } from './packageContainerApi'
 import {

--- a/shared/packages/api/src/status.ts
+++ b/shared/packages/api/src/status.ts
@@ -1,4 +1,5 @@
-import { StatusCode } from '@sofie-automation/blueprints-integration'
+// eslint-disable-next-line node/no-extraneous-import
+import { StatusCode } from '@sofie-automation/shared-lib/dist/lib/status'
 
 export interface Statuses {
 	[key: string]: { message: string; statusCode: StatusCode } | null

--- a/shared/packages/expectationManager/package.json
+++ b/shared/packages/expectationManager/package.json
@@ -1,35 +1,35 @@
 {
-  "name": "@sofie-package-manager/expectation-manager",
-  "version": "1.39.7",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "license": "MIT",
-  "scripts": {
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "test": "jest",
-    "precommit": "lint-staged"
-  },
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "devDependencies": {
-    "lint-staged": "^7.2.0"
-  },
-  "dependencies": {
-    "@sofie-package-manager/api": "1.39.2",
-    "@sofie-package-manager/worker": "1.39.7",
-    "@supercharge/promise-pool": "^1.7.0",
-    "underscore": "^1.12.0"
-  },
-  "peerDependencies": {},
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
-    ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "name": "@sofie-package-manager/expectation-manager",
+    "version": "1.39.7",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "license": "MIT",
+    "scripts": {
+        "build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "test": "jest",
+        "precommit": "lint-staged"
+    },
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "devDependencies": {
+        "lint-staged": "^7.2.0"
+    },
+    "dependencies": {
+        "@sofie-package-manager/api": "1.39.2",
+        "@sofie-package-manager/worker": "1.39.7",
+        "@supercharge/promise-pool": "^1.7.0",
+        "underscore": "^1.12.0"
+    },
+    "peerDependencies": {},
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/shared/packages/expectationManager/package.json
+++ b/shared/packages/expectationManager/package.json
@@ -1,37 +1,35 @@
 {
-    "name": "@sofie-package-manager/expectation-manager",
-    "version": "1.39.7",
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "license": "MIT",
-    "scripts": {
-        "build": "rimraf dist && yarn build:main",
-        "build:main": "tsc -p tsconfig.json",
-        "test": "jest",
-        "precommit": "lint-staged"
-    },
-    "engines": {
-        "node": ">=14.18.0"
-    },
-    "devDependencies": {
-        "lint-staged": "^7.2.0"
-    },
-    "dependencies": {
-        "@sofie-package-manager/api": "1.39.2",
-        "@sofie-package-manager/worker": "1.39.7",
-        "@supercharge/promise-pool": "^1.7.0",
-        "underscore": "^1.12.0"
-    },
-    "peerDependencies": {
-        "@sofie-automation/blueprints-integration": "*"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "lint-staged": {
-        "*.{js,css,json,md,scss}": [
-            "prettier"
-        ],
-        "*.{ts,tsx}": [
-            "eslint"
-        ]
-    }
+	"name": "@sofie-package-manager/expectation-manager",
+	"version": "1.39.7",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"license": "MIT",
+	"scripts": {
+		"build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.json",
+		"test": "jest",
+		"precommit": "lint-staged"
+	},
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"devDependencies": {
+		"lint-staged": "^7.2.0"
+	},
+	"dependencies": {
+		"@sofie-package-manager/api": "1.39.2",
+		"@sofie-package-manager/worker": "1.39.7",
+		"@supercharge/promise-pool": "^1.7.0",
+		"underscore": "^1.12.0"
+	},
+	"peerDependencies": {},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier"
+		],
+		"*.{ts,tsx}": [
+			"eslint"
+		]
+	}
 }

--- a/shared/packages/expectationManager/package.json
+++ b/shared/packages/expectationManager/package.json
@@ -1,35 +1,35 @@
 {
-	"name": "@sofie-package-manager/expectation-manager",
-	"version": "1.39.7",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"license": "MIT",
-	"scripts": {
-		"build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"test": "jest",
-		"precommit": "lint-staged"
-	},
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"devDependencies": {
-		"lint-staged": "^7.2.0"
-	},
-	"dependencies": {
-		"@sofie-package-manager/api": "1.39.2",
-		"@sofie-package-manager/worker": "1.39.7",
-		"@supercharge/promise-pool": "^1.7.0",
-		"underscore": "^1.12.0"
-	},
-	"peerDependencies": {},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@sofie-package-manager/expectation-manager",
+  "version": "1.39.7",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "license": "MIT",
+  "scripts": {
+    "build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "test": "jest",
+    "precommit": "lint-staged"
+  },
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "devDependencies": {
+    "lint-staged": "^7.2.0"
+  },
+  "dependencies": {
+    "@sofie-package-manager/api": "1.39.2",
+    "@sofie-package-manager/worker": "1.39.7",
+    "@supercharge/promise-pool": "^1.7.0",
+    "underscore": "^1.12.0"
+  },
+  "peerDependencies": {},
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/shared/packages/expectationManager/src/expectationManager.ts
+++ b/shared/packages/expectationManager/src/expectationManager.ts
@@ -23,7 +23,8 @@ import {
 	hashObj,
 	setLogLevel,
 } from '@sofie-package-manager/api'
-import { ExpectedPackageStatusAPI } from '@sofie-automation/blueprints-integration'
+// eslint-disable-next-line node/no-extraneous-import
+import { ExpectedPackageStatusAPI } from '@sofie-automation/shared-lib/dist/package-manager/package'
 import { WorkforceAPI } from './workforceApi'
 import { WorkerAgentAPI } from './workerAgentApi'
 import PromisePool from '@supercharge/promise-pool'

--- a/shared/packages/expectationManager/src/lib/expectations.ts
+++ b/shared/packages/expectationManager/src/lib/expectations.ts
@@ -1,5 +1,6 @@
 import { Expectation } from '@sofie-package-manager/api'
-import { ExpectedPackageStatusAPI } from '@sofie-automation/blueprints-integration'
+// eslint-disable-next-line node/no-extraneous-import
+import { ExpectedPackageStatusAPI } from '@sofie-automation/shared-lib/dist/package-manager/package'
 import { ExpectationManagerConstants } from './constants'
 import { TrackedExpectation } from './types'
 

--- a/shared/packages/expectationManager/src/lib/types.ts
+++ b/shared/packages/expectationManager/src/lib/types.ts
@@ -1,5 +1,6 @@
 import { Expectation, ExpectationManagerWorkerAgent, Reason } from '@sofie-package-manager/api'
-import { ExpectedPackageStatusAPI } from '@sofie-automation/blueprints-integration'
+// eslint-disable-next-line node/no-extraneous-import
+import { ExpectedPackageStatusAPI } from '@sofie-automation/shared-lib/dist/package-manager/package'
 import { WorkerAgentAPI } from '../workerAgentApi'
 
 export interface TrackedExpectation {

--- a/shared/packages/worker/package.json
+++ b/shared/packages/worker/package.json
@@ -1,46 +1,46 @@
 {
-  "name": "@sofie-package-manager/worker",
-  "version": "1.39.7",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "license": "MIT",
-  "scripts": {
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "__test": "jest",
-    "precommit": "lint-staged"
-  },
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "devDependencies": {
-    "@types/deep-diff": "^1.0.0",
-    "@types/node-fetch": "^2.5.8",
-    "@types/tmp": "~0.2.2",
-    "lint-staged": "^7.2.0"
-  },
-  "dependencies": {
-    "@sofie-package-manager/api": "1.39.2",
-    "abort-controller": "^3.0.0",
-    "atem-connection": "3.0.0-nightly-latest-20211125-222857-2b30eea.0",
-    "chokidar": "^3.5.1",
-    "deep-diff": "^1.0.2",
-    "form-data": "^4.0.0",
-    "mkdirp": "^1.0.4",
-    "node-fetch": "^2.6.1",
-    "tmp": "~0.2.1",
-    "tv-automation-quantel-gateway-client": "3.0.3",
-    "windows-network-drive": "^3.0.1",
-    "xml-js": "^1.6.11"
-  },
-  "peerDependencies": {},
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
-    ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "name": "@sofie-package-manager/worker",
+    "version": "1.39.7",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "license": "MIT",
+    "scripts": {
+        "build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "__test": "jest",
+        "precommit": "lint-staged"
+    },
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "devDependencies": {
+        "@types/deep-diff": "^1.0.0",
+        "@types/node-fetch": "^2.5.8",
+        "@types/tmp": "~0.2.2",
+        "lint-staged": "^7.2.0"
+    },
+    "dependencies": {
+        "@sofie-package-manager/api": "1.39.2",
+        "abort-controller": "^3.0.0",
+        "atem-connection": "3.0.0-nightly-latest-20211125-222857-2b30eea.0",
+        "chokidar": "^3.5.1",
+        "deep-diff": "^1.0.2",
+        "form-data": "^4.0.0",
+        "mkdirp": "^1.0.4",
+        "node-fetch": "^2.6.1",
+        "tmp": "~0.2.1",
+        "tv-automation-quantel-gateway-client": "3.0.3",
+        "windows-network-drive": "^3.0.1",
+        "xml-js": "^1.6.11"
+    },
+    "peerDependencies": {},
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/shared/packages/worker/package.json
+++ b/shared/packages/worker/package.json
@@ -1,46 +1,46 @@
 {
-	"name": "@sofie-package-manager/worker",
-	"version": "1.39.7",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"license": "MIT",
-	"scripts": {
-		"build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"__test": "jest",
-		"precommit": "lint-staged"
-	},
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"devDependencies": {
-		"@types/deep-diff": "^1.0.0",
-		"@types/node-fetch": "^2.5.8",
-		"@types/tmp": "~0.2.2",
-		"lint-staged": "^7.2.0"
-	},
-	"dependencies": {
-		"@sofie-package-manager/api": "1.39.2",
-		"abort-controller": "^3.0.0",
-		"atem-connection": "3.0.0-nightly-latest-20211125-222857-2b30eea.0",
-		"chokidar": "^3.5.1",
-		"deep-diff": "^1.0.2",
-		"form-data": "^4.0.0",
-		"mkdirp": "^1.0.4",
-		"node-fetch": "^2.6.1",
-		"tmp": "~0.2.1",
-		"tv-automation-quantel-gateway-client": "3.0.3",
-		"windows-network-drive": "^3.0.1",
-		"xml-js": "^1.6.11"
-	},
-	"peerDependencies": {},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@sofie-package-manager/worker",
+  "version": "1.39.7",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "license": "MIT",
+  "scripts": {
+    "build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "__test": "jest",
+    "precommit": "lint-staged"
+  },
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "devDependencies": {
+    "@types/deep-diff": "^1.0.0",
+    "@types/node-fetch": "^2.5.8",
+    "@types/tmp": "~0.2.2",
+    "lint-staged": "^7.2.0"
+  },
+  "dependencies": {
+    "@sofie-package-manager/api": "1.39.2",
+    "abort-controller": "^3.0.0",
+    "atem-connection": "3.0.0-nightly-latest-20211125-222857-2b30eea.0",
+    "chokidar": "^3.5.1",
+    "deep-diff": "^1.0.2",
+    "form-data": "^4.0.0",
+    "mkdirp": "^1.0.4",
+    "node-fetch": "^2.6.1",
+    "tmp": "~0.2.1",
+    "tv-automation-quantel-gateway-client": "3.0.3",
+    "windows-network-drive": "^3.0.1",
+    "xml-js": "^1.6.11"
+  },
+  "peerDependencies": {},
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/shared/packages/worker/package.json
+++ b/shared/packages/worker/package.json
@@ -33,9 +33,7 @@
 		"windows-network-drive": "^3.0.1",
 		"xml-js": "^1.6.11"
 	},
-	"peerDependencies": {
-		"@sofie-automation/blueprints-integration": "*"
-	},
+	"peerDependencies": {},
 	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
 	"lint-staged": {
 		"*.{js,css,json,md,scss}": [

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/lib/quantel.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/lib/quantel.ts
@@ -1,4 +1,5 @@
-import { AccessorOnPackage, Accessor } from '@sofie-automation/blueprints-integration'
+// eslint-disable-next-line node/no-extraneous-import
+import { AccessorOnPackage, Accessor } from '@sofie-automation/shared-lib/dist/package-manager/package'
 import { Expectation, literal } from '@sofie-package-manager/api'
 import { getAccessorHandle, isHTTPProxyAccessorHandle } from '../../../../accessorHandlers/accessor'
 import { GenericAccessorHandle } from '../../../../accessorHandlers/genericHandle'

--- a/shared/packages/workforce/package.json
+++ b/shared/packages/workforce/package.json
@@ -1,37 +1,35 @@
 {
-    "name": "@sofie-package-manager/workforce",
-    "version": "1.39.2",
-    "main": "dist/index",
-    "types": "dist/index",
-    "files": [
-        "dist"
-    ],
-    "license": "MIT",
-    "scripts": {
-        "build": "rimraf dist && yarn build:main",
-        "build:main": "tsc -p tsconfig.json",
-        "__test": "jest",
-        "precommit": "lint-staged"
-    },
-    "peerDependencies": {
-        "@sofie-automation/blueprints-integration": "*"
-    },
-    "devDependencies": {
-        "lint-staged": "^7.2.0"
-    },
-    "dependencies": {
-        "@sofie-package-manager/api": "1.39.2"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "engines": {
-        "node": ">=14.18.0"
-    },
-    "lint-staged": {
-        "*.{js,css,json,md,scss}": [
-            "prettier"
-        ],
-        "*.{ts,tsx}": [
-            "eslint"
-        ]
-    }
+	"name": "@sofie-package-manager/workforce",
+	"version": "1.39.2",
+	"main": "dist/index",
+	"types": "dist/index",
+	"files": [
+		"dist"
+	],
+	"license": "MIT",
+	"scripts": {
+		"build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.json",
+		"__test": "jest",
+		"precommit": "lint-staged"
+	},
+	"peerDependencies": {},
+	"devDependencies": {
+		"lint-staged": "^7.2.0"
+	},
+	"dependencies": {
+		"@sofie-package-manager/api": "1.39.2"
+	},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier"
+		],
+		"*.{ts,tsx}": [
+			"eslint"
+		]
+	}
 }

--- a/shared/packages/workforce/package.json
+++ b/shared/packages/workforce/package.json
@@ -1,35 +1,35 @@
 {
-  "name": "@sofie-package-manager/workforce",
-  "version": "1.39.2",
-  "main": "dist/index",
-  "types": "dist/index",
-  "files": [
-    "dist"
-  ],
-  "license": "MIT",
-  "scripts": {
-    "build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "__test": "jest",
-    "precommit": "lint-staged"
-  },
-  "peerDependencies": {},
-  "devDependencies": {
-    "lint-staged": "^7.2.0"
-  },
-  "dependencies": {
-    "@sofie-package-manager/api": "1.39.2"
-  },
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
+    "name": "@sofie-package-manager/workforce",
+    "version": "1.39.2",
+    "main": "dist/index",
+    "types": "dist/index",
+    "files": [
+        "dist"
     ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "license": "MIT",
+    "scripts": {
+        "build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "__test": "jest",
+        "precommit": "lint-staged"
+    },
+    "peerDependencies": {},
+    "devDependencies": {
+        "lint-staged": "^7.2.0"
+    },
+    "dependencies": {
+        "@sofie-package-manager/api": "1.39.2"
+    },
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/shared/packages/workforce/package.json
+++ b/shared/packages/workforce/package.json
@@ -1,35 +1,35 @@
 {
-	"name": "@sofie-package-manager/workforce",
-	"version": "1.39.2",
-	"main": "dist/index",
-	"types": "dist/index",
-	"files": [
-		"dist"
-	],
-	"license": "MIT",
-	"scripts": {
-		"build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"__test": "jest",
-		"precommit": "lint-staged"
-	},
-	"peerDependencies": {},
-	"devDependencies": {
-		"lint-staged": "^7.2.0"
-	},
-	"dependencies": {
-		"@sofie-package-manager/api": "1.39.2"
-	},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@sofie-package-manager/workforce",
+  "version": "1.39.2",
+  "main": "dist/index",
+  "types": "dist/index",
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "scripts": {
+    "build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "__test": "jest",
+    "precommit": "lint-staged"
+  },
+  "peerDependencies": {},
+  "devDependencies": {
+    "lint-staged": "^7.2.0"
+  },
+  "dependencies": {
+    "@sofie-package-manager/api": "1.39.2"
+  },
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/tests/internal-tests/package.json
+++ b/tests/internal-tests/package.json
@@ -1,41 +1,41 @@
 {
-  "name": "@tests/internal-tests",
-  "version": "1.39.7",
-  "description": "Internal tests",
-  "private": true,
-  "scripts": {
-    "__build": "rimraf dist && yarn build:main",
-    "build:main": "tsc -p tsconfig.json",
-    "test": "jest --runInBand",
-    "precommit": "lint-staged"
-  },
-  "devDependencies": {
-    "deep-extend": "^0.6.0",
-    "lint-staged": "^7.2.0",
-    "nexe": "^3.3.7",
-    "tv-automation-quantel-gateway-client": "^2.0.2",
-    "windows-network-drive": "^3.0.1"
-  },
-  "dependencies": {
-    "@http-server/generic": "1.39.2",
-    "@package-manager/generic": "1.39.7",
-    "@sofie-package-manager/api": "1.39.2",
-    "@sofie-package-manager/expectation-manager": "1.39.7",
-    "@sofie-package-manager/worker": "1.39.7",
-    "@sofie-package-manager/workforce": "1.39.2",
-    "underscore": "^1.12.0"
-  },
-  "peerDependencies": {},
-  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-  "engines": {
-    "node": ">=14.18.0"
-  },
-  "lint-staged": {
-    "*.{js,css,json,md,scss}": [
-      "prettier"
-    ],
-    "*.{ts,tsx}": [
-      "eslint"
-    ]
-  }
+    "name": "@tests/internal-tests",
+    "version": "1.39.7",
+    "description": "Internal tests",
+    "private": true,
+    "scripts": {
+        "__build": "rimraf dist && yarn build:main",
+        "build:main": "tsc -p tsconfig.json",
+        "test": "jest --runInBand",
+        "precommit": "lint-staged"
+    },
+    "devDependencies": {
+        "deep-extend": "^0.6.0",
+        "lint-staged": "^7.2.0",
+        "nexe": "^3.3.7",
+        "tv-automation-quantel-gateway-client": "^2.0.2",
+        "windows-network-drive": "^3.0.1"
+    },
+    "dependencies": {
+        "@http-server/generic": "1.39.2",
+        "@package-manager/generic": "1.39.7",
+        "@sofie-package-manager/api": "1.39.2",
+        "@sofie-package-manager/expectation-manager": "1.39.7",
+        "@sofie-package-manager/worker": "1.39.7",
+        "@sofie-package-manager/workforce": "1.39.2",
+        "underscore": "^1.12.0"
+    },
+    "peerDependencies": {},
+    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+    "engines": {
+        "node": ">=14.18.0"
+    },
+    "lint-staged": {
+        "*.{js,css,json,md,scss}": [
+            "prettier"
+        ],
+        "*.{ts,tsx}": [
+            "eslint"
+        ]
+    }
 }

--- a/tests/internal-tests/package.json
+++ b/tests/internal-tests/package.json
@@ -1,43 +1,41 @@
 {
-    "name": "@tests/internal-tests",
-    "version": "1.39.7",
-    "description": "Internal tests",
-    "private": true,
-    "scripts": {
-        "__build": "rimraf dist && yarn build:main",
-        "build:main": "tsc -p tsconfig.json",
-        "test": "jest --runInBand",
-        "precommit": "lint-staged"
-    },
-    "devDependencies": {
-        "deep-extend": "^0.6.0",
-        "lint-staged": "^7.2.0",
-        "nexe": "^3.3.7",
-        "tv-automation-quantel-gateway-client": "^2.0.2",
-        "windows-network-drive": "^3.0.1"
-    },
-    "dependencies": {
-        "@http-server/generic": "1.39.2",
-        "@package-manager/generic": "1.39.7",
-        "@sofie-package-manager/api": "1.39.2",
-        "@sofie-package-manager/expectation-manager": "1.39.7",
-        "@sofie-package-manager/worker": "1.39.7",
-        "@sofie-package-manager/workforce": "1.39.2",
-        "underscore": "^1.12.0"
-    },
-    "peerDependencies": {
-        "@sofie-automation/blueprints-integration": "*"
-    },
-    "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-    "engines": {
-        "node": ">=14.18.0"
-    },
-    "lint-staged": {
-        "*.{js,css,json,md,scss}": [
-            "prettier"
-        ],
-        "*.{ts,tsx}": [
-            "eslint"
-        ]
-    }
+	"name": "@tests/internal-tests",
+	"version": "1.39.7",
+	"description": "Internal tests",
+	"private": true,
+	"scripts": {
+		"__build": "rimraf dist && yarn build:main",
+		"build:main": "tsc -p tsconfig.json",
+		"test": "jest --runInBand",
+		"precommit": "lint-staged"
+	},
+	"devDependencies": {
+		"deep-extend": "^0.6.0",
+		"lint-staged": "^7.2.0",
+		"nexe": "^3.3.7",
+		"tv-automation-quantel-gateway-client": "^2.0.2",
+		"windows-network-drive": "^3.0.1"
+	},
+	"dependencies": {
+		"@http-server/generic": "1.39.2",
+		"@package-manager/generic": "1.39.7",
+		"@sofie-package-manager/api": "1.39.2",
+		"@sofie-package-manager/expectation-manager": "1.39.7",
+		"@sofie-package-manager/worker": "1.39.7",
+		"@sofie-package-manager/workforce": "1.39.2",
+		"underscore": "^1.12.0"
+	},
+	"peerDependencies": {},
+	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+	"engines": {
+		"node": ">=14.18.0"
+	},
+	"lint-staged": {
+		"*.{js,css,json,md,scss}": [
+			"prettier"
+		],
+		"*.{ts,tsx}": [
+			"eslint"
+		]
+	}
 }

--- a/tests/internal-tests/package.json
+++ b/tests/internal-tests/package.json
@@ -1,41 +1,41 @@
 {
-	"name": "@tests/internal-tests",
-	"version": "1.39.7",
-	"description": "Internal tests",
-	"private": true,
-	"scripts": {
-		"__build": "rimraf dist && yarn build:main",
-		"build:main": "tsc -p tsconfig.json",
-		"test": "jest --runInBand",
-		"precommit": "lint-staged"
-	},
-	"devDependencies": {
-		"deep-extend": "^0.6.0",
-		"lint-staged": "^7.2.0",
-		"nexe": "^3.3.7",
-		"tv-automation-quantel-gateway-client": "^2.0.2",
-		"windows-network-drive": "^3.0.1"
-	},
-	"dependencies": {
-		"@http-server/generic": "1.39.2",
-		"@package-manager/generic": "1.39.7",
-		"@sofie-package-manager/api": "1.39.2",
-		"@sofie-package-manager/expectation-manager": "1.39.7",
-		"@sofie-package-manager/worker": "1.39.7",
-		"@sofie-package-manager/workforce": "1.39.2",
-		"underscore": "^1.12.0"
-	},
-	"peerDependencies": {},
-	"prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
-	"engines": {
-		"node": ">=14.18.0"
-	},
-	"lint-staged": {
-		"*.{js,css,json,md,scss}": [
-			"prettier"
-		],
-		"*.{ts,tsx}": [
-			"eslint"
-		]
-	}
+  "name": "@tests/internal-tests",
+  "version": "1.39.7",
+  "description": "Internal tests",
+  "private": true,
+  "scripts": {
+    "__build": "rimraf dist && yarn build:main",
+    "build:main": "tsc -p tsconfig.json",
+    "test": "jest --runInBand",
+    "precommit": "lint-staged"
+  },
+  "devDependencies": {
+    "deep-extend": "^0.6.0",
+    "lint-staged": "^7.2.0",
+    "nexe": "^3.3.7",
+    "tv-automation-quantel-gateway-client": "^2.0.2",
+    "windows-network-drive": "^3.0.1"
+  },
+  "dependencies": {
+    "@http-server/generic": "1.39.2",
+    "@package-manager/generic": "1.39.7",
+    "@sofie-package-manager/api": "1.39.2",
+    "@sofie-package-manager/expectation-manager": "1.39.7",
+    "@sofie-package-manager/worker": "1.39.7",
+    "@sofie-package-manager/workforce": "1.39.2",
+    "underscore": "^1.12.0"
+  },
+  "peerDependencies": {},
+  "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
+  "engines": {
+    "node": ">=14.18.0"
+  },
+  "lint-staged": {
+    "*.{js,css,json,md,scss}": [
+      "prettier"
+    ],
+    "*.{ts,tsx}": [
+      "eslint"
+    ]
+  }
 }

--- a/tests/internal-tests/src/__tests__/basic.spec.ts
+++ b/tests/internal-tests/src/__tests__/basic.spec.ts
@@ -1,7 +1,8 @@
 import fsOrg from 'fs'
 import { promisify } from 'util'
 import WNDOrg from 'windows-network-drive'
-import { ExpectedPackageStatusAPI } from '@sofie-automation/blueprints-integration'
+// eslint-disable-next-line node/no-extraneous-import
+import { ExpectedPackageStatusAPI } from '@sofie-automation/shared-lib/dist/package-manager/package'
 import * as QGatewayClientOrg from 'tv-automation-quantel-gateway-client'
 import { Expectation, literal } from '@sofie-package-manager/api'
 import type * as fsMockType from '../__mocks__/fs'

--- a/tests/internal-tests/src/__tests__/issues.spec.ts
+++ b/tests/internal-tests/src/__tests__/issues.spec.ts
@@ -1,6 +1,7 @@
 import fsOrg from 'fs'
 import { promisify } from 'util'
-import { ExpectedPackageStatusAPI } from '@sofie-automation/blueprints-integration'
+// eslint-disable-next-line node/no-extraneous-import
+import { ExpectedPackageStatusAPI } from '@sofie-automation/shared-lib/dist/package-manager/package'
 import { Expectation, literal } from '@sofie-package-manager/api'
 import type * as fsMockType from '../__mocks__/fs'
 import { prepareTestEnviromnent, TestEnviromnent } from './lib/setupEnv'
@@ -12,7 +13,7 @@ jest.mock('child_process')
 jest.mock('windows-network-drive')
 jest.mock('tv-automation-quantel-gateway-client')
 
-const fs = (fsOrg as any) as typeof fsMockType
+const fs = fsOrg as any as typeof fsMockType
 
 const fsStat = promisify(fs.stat)
 

--- a/tests/internal-tests/src/__tests__/lib/setupEnv.ts
+++ b/tests/internal-tests/src/__tests__/lib/setupEnv.ts
@@ -22,7 +22,8 @@ import {
 	ExpectationManagerOptions,
 } from '@sofie-package-manager/expectation-manager'
 import { CoreMockAPI } from './coreMockAPI'
-import { ExpectedPackageStatusAPI } from '@sofie-automation/blueprints-integration'
+// eslint-disable-next-line node/no-extraneous-import
+import { ExpectedPackageStatusAPI } from '@sofie-automation/shared-lib/dist/package-manager/package'
 
 const defaultTestConfig: SingleAppConfig = {
 	singleApp: {

--- a/tests/internal-tests/src/__tests__/quantel.spec.ts
+++ b/tests/internal-tests/src/__tests__/quantel.spec.ts
@@ -1,4 +1,5 @@
-import { ExpectedPackageStatusAPI } from '@sofie-automation/blueprints-integration'
+// eslint-disable-next-line node/no-extraneous-import
+import { ExpectedPackageStatusAPI } from '@sofie-automation/shared-lib/dist/package-manager/package'
 import * as QGatewayClientOrg from 'tv-automation-quantel-gateway-client'
 import { Expectation, literal } from '@sofie-package-manager/api'
 import type * as QGatewayClientType from '../__mocks__/tv-automation-quantel-gateway-client'
@@ -8,7 +9,7 @@ import { getQuantelSource, getQuantelTarget } from './lib/containers'
 jest.mock('child_process')
 jest.mock('tv-automation-quantel-gateway-client')
 
-const QGatewayClient = (QGatewayClientOrg as any) as typeof QGatewayClientType
+const QGatewayClient = QGatewayClientOrg as any as typeof QGatewayClientType
 
 describe('Quantel', () => {
 	let env: TestEnviromnent

--- a/yarn.lock
+++ b/yarn.lock
@@ -1577,15 +1577,15 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@sofie-automation/blueprints-integration@1.38.0-nightly-release38-20211208-162831-102085a.0":
-  version "1.38.0-nightly-release38-20211208-162831-102085a.0"
-  resolved "https://registry.yarnpkg.com/@sofie-automation/blueprints-integration/-/blueprints-integration-1.38.0-nightly-release38-20211208-162831-102085a.0.tgz#381e44642dd901f196479c8c824a26464473e35c"
-  integrity sha512-W7kW5VTQ1Ku3mGow7Jh4G+wZYpXYBnkXHhLdPT10qcxYrDQrswpTM3561VTUTPPHaDmqk6UHOGjKe8IPns/ERA==
+"@sofie-automation/blueprints-integration@1.44.1":
+  version "1.44.1"
+  resolved "https://registry.yarnpkg.com/@sofie-automation/blueprints-integration/-/blueprints-integration-1.44.1.tgz#d0cc3c7af92b159f59d5435f210839714535c8c5"
+  integrity sha512-d/EQBz7nPDUEkaA+aBhz9TLX4iXng0aA0PWSPxUESCWLMYbhZQlW0BsmpddOdmMYkRqYpeELC7evbGH0FKVpPQ==
   dependencies:
-    moment "2.29.1"
-    timeline-state-resolver-types "6.3.0-nightly-release38-20211208-151539-570b2cfb5.0"
-    tslib "^2.3.1"
-    underscore "1.13.1"
+    "@sofie-automation/shared-lib" "1.44.1"
+    timeline-state-resolver-types "7.3.0"
+    tslib "^2.4.0"
+    type-fest "^2.12.2"
 
 "@sofie-automation/code-standard-preset@^0.2.1":
   version "0.2.5"
@@ -1626,17 +1626,27 @@
     read-pkg-up "^9.1.0"
     shelljs "^0.8.5"
 
-"@sofie-automation/server-core-integration@1.38.0-nightly-release38-20211208-162831-102085a.0":
-  version "1.38.0-nightly-release38-20211208-162831-102085a.0"
-  resolved "https://registry.yarnpkg.com/@sofie-automation/server-core-integration/-/server-core-integration-1.38.0-nightly-release38-20211208-162831-102085a.0.tgz#8f5d733414485078db26a352da738b1f0cad65cf"
-  integrity sha512-8fG1ponVo4ucFJ5KsXX1a7XrX9RZv2VaFdHW2OpG0OnKL+WjJmyubu+XomG7ll8op3RFlIfFSRle2pdNlYaVvg==
+"@sofie-automation/server-core-integration@1.44.1":
+  version "1.44.1"
+  resolved "https://registry.yarnpkg.com/@sofie-automation/server-core-integration/-/server-core-integration-1.44.1.tgz#eb6a0bb7c8dc1bdbb27c0582f650f57b750d53c5"
+  integrity sha512-/jIXwN8FhgE5LE3Njts8y9Ax8Wlnw5AYNr2TxWZAQYpG3Qv3J2Q+z4pDOUWb5lilm/a1r1pE17KtUZoDuydc9Q==
   dependencies:
+    "@sofie-automation/shared-lib" "1.44.1"
     data-store "^4.0.3"
-    ejson "^2.2.0"
+    ejson "^2.2.2"
+    eventemitter3 "^4.0.7"
     faye-websocket "^0.11.4"
-    got "^11.8.2"
-    tslib "^2.3.1"
-    underscore "^1.12.1"
+    got "^11.8.5"
+    tslib "^2.4.0"
+    underscore "^1.13.3"
+
+"@sofie-automation/shared-lib@1.44.1":
+  version "1.44.1"
+  resolved "https://registry.yarnpkg.com/@sofie-automation/shared-lib/-/shared-lib-1.44.1.tgz#ea641c81ffe0705abd24a134f8b3f792cf9dbb77"
+  integrity sha512-6zsZdpebIDMnpUkBoAjqKw1qRnvVDnV98hAePyUOf0mWCsC/Ao/Y0I75HzVC2v5pskhDVdBBGqqLmk5EhRG2RA==
+  dependencies:
+    tslib "^2.4.0"
+    type-fest "^2.12.2"
 
 "@stroncium/procfs@^1.2.1":
   version "1.2.1"
@@ -4123,10 +4133,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-ejson@^2.2.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/ejson/-/ejson-2.2.2.tgz#095bf356a57295784cada6ff19b2b2abc70e4f9d"
-  integrity sha512-Wc/PZH7WMxuM6eBpAuD9+IX98q27hlBTD8nvhh7UyGy22eB9qTRG0oAzlviicADh9VVxYp+/onTyfYZC3DhI5w==
+ejson@^2.2.2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/ejson/-/ejson-2.2.3.tgz#2b18c2d8f5d61a5cfc6e3eab72c3343909e7afd2"
+  integrity sha512-hsFvJp6OpGxFRQfBR3PSxFpaPALdHDY+SB3TRbMpLWNhvu8GzLiZutof5+/DFd2QekZo3KyXau75ngdJqQUSrw==
 
 electron-to-chromium@^1.4.172:
   version "1.4.182"
@@ -5508,7 +5518,7 @@ globby@^9.2.0:
     pify "^4.0.1"
     slash "^2.0.0"
 
-got@^11.8.2, got@^11.8.5:
+got@^11.8.5:
   version "11.8.5"
   resolved "https://registry.yarnpkg.com/got/-/got-11.8.5.tgz#ce77d045136de56e8f024bebb82ea349bc730046"
   integrity sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==
@@ -8035,11 +8045,6 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
-
-moment@2.29.1:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 mount-point@^3.0.0:
   version "3.0.0"
@@ -10710,10 +10715,10 @@ timed-out@^4.0.1:
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==
 
-timeline-state-resolver-types@6.3.0-nightly-release38-20211208-151539-570b2cfb5.0:
-  version "6.3.0-nightly-release38-20211208-151539-570b2cfb5.0"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-6.3.0-nightly-release38-20211208-151539-570b2cfb5.0.tgz#d8f0c7525bb1510fddf6ce8811e6a6c064a8a92c"
-  integrity sha512-suaEpBfjdFEM+v2AL6ugLUjFYkclU2TRbiPj7T5PVgGBzulR/7c1so1jiUqXXTtisMiCB0tQsyQPGNO9qkxcVw==
+timeline-state-resolver-types@7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.3.0.tgz#72515377c89a2ac253158b577bba3d9ffbf8d7c2"
+  integrity sha512-Y4fmmP0aut9LjpnnDzu1BliUhAYgAe+ygQsAx3uxMkpYGBEs/A/1wROv4WGyKpsqtf3PjeyDch92s1Femq3TSA==
   dependencies:
     tslib "^2.3.1"
 
@@ -10911,6 +10916,11 @@ tslib@^2.1.0, tslib@^2.3.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
+tslib@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+
 tsscmp@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
@@ -11015,6 +11025,11 @@ type-fest@^2.0.0, type-fest@^2.5.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.16.0.tgz#1250fbd64dafaf4c8e405e393ef3fb16d9651db2"
   integrity sha512-qpaThT2HQkFb83gMOrdKVsfCN7LKxP26Yq+smPzY1FqoHRjqmjqHXA7n5Gkxi8efirtbeEUxzfEdePthQWCuHw==
 
+type-fest@^2.12.2:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
+
 type-is@^1.6.16, type-is@^1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
@@ -11078,15 +11093,15 @@ unbzip2-stream@^1.0.9:
     buffer "^5.2.1"
     through "^2.3.8"
 
-underscore@1.13.1:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
-  integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==
-
-underscore@^1.12.0, underscore@^1.12.1:
+underscore@^1.12.0:
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.4.tgz#7886b46bbdf07f768e0052f1828e1dcab40c0dee"
   integrity sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ==
+
+underscore@^1.13.3:
+  version "1.13.6"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
+  integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
 union-value@^1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1577,16 +1577,6 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@sofie-automation/blueprints-integration@1.44.1":
-  version "1.44.1"
-  resolved "https://registry.yarnpkg.com/@sofie-automation/blueprints-integration/-/blueprints-integration-1.44.1.tgz#d0cc3c7af92b159f59d5435f210839714535c8c5"
-  integrity sha512-d/EQBz7nPDUEkaA+aBhz9TLX4iXng0aA0PWSPxUESCWLMYbhZQlW0BsmpddOdmMYkRqYpeELC7evbGH0FKVpPQ==
-  dependencies:
-    "@sofie-automation/shared-lib" "1.44.1"
-    timeline-state-resolver-types "7.3.0"
-    tslib "^2.4.0"
-    type-fest "^2.12.2"
-
 "@sofie-automation/code-standard-preset@^0.2.1":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@sofie-automation/code-standard-preset/-/code-standard-preset-0.2.5.tgz#d1f8135a88e6b0b4dd8bf8f83f7a69733194a718"
@@ -10714,13 +10704,6 @@ timed-out@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==
-
-timeline-state-resolver-types@7.3.0:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-7.3.0.tgz#72515377c89a2ac253158b577bba3d9ffbf8d7c2"
-  integrity sha512-Y4fmmP0aut9LjpnnDzu1BliUhAYgAe+ygQsAx3uxMkpYGBEs/A/1wROv4WGyKpsqtf3PjeyDch92s1Femq3TSA==
-  dependencies:
-    tslib "^2.3.1"
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
update @sofie-automation/server-core-integration to a release version (instead of a random nightly version). In doing so, the dependency on @sofie-automation/blueprints-integration is no longer necessary as any used types have moved to @sofie-automation/shared-lib