### PR TITLE
chore: build windows binaries in ci

### DIFF
--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -3,14 +3,17 @@ name: Build Windows
 on:
   workflow_dispatch:
   push:
-    # tags:
-    #   - 'v*.*.*'
+    branches:
+      - master
+      - 'release**'
+    tags:
+      - 'v**'
 
 jobs:
   build:
     name: Build windows binaries
     runs-on: windows-latest
-    timeout-minutes: 150
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v3
@@ -50,3 +53,26 @@ jobs:
         with:
           name: Windows
           path: deploy
+
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+      - build
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: Windows
+          path: deploy
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: deploy/*
+          fail_on_unmatched_files: true

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -1,0 +1,52 @@
+name: Build Windows
+
+on:
+  workflow_dispatch:
+  push:
+    # tags:
+    #   - 'v*.*.*'
+
+jobs:
+  build:
+    name: Build windows binaries
+    runs-on: windows-latest
+    timeout-minutes: 150
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+
+      - name: Run build
+        run: yarn do:build-win32
+        env:
+          CI: true
+
+      - name: sign executables
+        shell: bash
+        continue-on-error: true
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+        run: |
+          if [[ ! -z "$WINDOWS_CERTIFICATE" ]]; then
+            # write certficate to file
+            echo "$WINDOWS_CERTIFICATE" | base64 -d > certificate.pfx
+
+            for FILE in deploy/*; do
+              # This path is a bit fragile, but necessary as no signtool is on the path. 
+              # If this path breaks, then find what versions of windows kits are installed in the updated runner image https://github.com/actions/runner-images#available-images
+              'C:/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x86/signtool.exe' sign //fd SHA256 //f certificate.pfx //p "${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}" $FILE
+              echo $FILE
+            done
+          else
+            echo "No certificate found"
+          fi
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Windows
+          path: deploy

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "start:worker": "lerna run start --stream --scope @worker/app",
         "start:single-app": "lerna run start --stream --scope @single-app/app",
         "postinstall": "node scripts/update-packages.js",
-        "do:build-win32": "yarn install && yarn build && yarn build-win32 && yarn gather-built && yarn sign-executables"
+        "do:build-win32": "yarn install && yarn build && yarn build-win32 && yarn gather-built"
     },
     "devDependencies": {
         "@sofie-automation/code-standard-preset": "^2.0.2",


### PR DESCRIPTION
builds are produced for each push to `master` or `release**` branch, and made available as an artifact on the workflow run. This workflow can also be triggered manually for any other branch.  
any tags pushed will also be built, and will have the produced binaries published as a release

example run producing a release:
https://github.com/Julusian/sofie-package-manager/actions/runs/3911835824/jobs/6685687396
https://github.com/Julusian/sofie-package-manager/releases/tag/v0.0.1

note: as this is a fork, it is skipping the signing step.

signing is shown to be working:
https://github.com/nrkno/sofie-package-manager/actions/runs/3910714913/jobs/6683239584