### PR TITLE
fix: exp jump NEW -> WAITING -> NEW when waiting for another exp

### DIFF
--- a/shared/packages/expectationManager/src/expectationManager.ts
+++ b/shared/packages/expectationManager/src/expectationManager.ts
@@ -1057,12 +1057,21 @@ export class ExpectationManager extends HelpfulEventEmitter {
 								})
 							} else {
 								// Not ready to start
-								this.updateTrackedExpStatus(trackedExp, {
-									state: ExpectedPackageStatusAPI.WorkStatusState.NEW,
-									reason: readyToStart.reason,
-									status: newStatus,
-									isError: !readyToStart.isWaitingForAnother,
-								})
+								if (readyToStart.isWaitingForAnother) {
+									// Not ready to start because it's waiting for another expectation to be fullfilled first
+									// Stay here in WAITING state:
+									this.updateTrackedExpStatus(trackedExp, {
+										reason: readyToStart.reason,
+										status: newStatus,
+									})
+								} else {
+									// Not ready to start because of some other reason (e.g. the source doesn't exist)
+									this.updateTrackedExpStatus(trackedExp, {
+										state: ExpectedPackageStatusAPI.WorkStatusState.NEW,
+										reason: readyToStart.reason,
+										status: newStatus,
+									})
+								}
 							}
 						}
 					} catch (error) {


### PR DESCRIPTION
fix: when an exp is waiting for another exp, it will be jumping between WAITING and NEW unnecessarily.

This changes the behaviour so that it stays in WAITING state.