### PR TITLE
Fix: Failing unit tests

### DIFF
--- a/apps/package-manager/packages/generic/src/packageManager.ts
+++ b/apps/package-manager/packages/generic/src/packageManager.ts
@@ -87,7 +87,7 @@ export class PackageManagerHandler {
 		private serverOptions: ExpectationManagerServerOptions,
 		private serverAccessUrl: string | undefined,
 		private workForceConnectionOptions: ClientConnectionOptions,
-		concurrency: number,
+		concurrency: number | undefined,
 		chaosMonkey: boolean
 	) {
 		this.logger = logger.category('PackageManager')

--- a/apps/single-app/app/src/singleApp.ts
+++ b/apps/single-app/app/src/singleApp.ts
@@ -64,7 +64,7 @@ export async function startSingleApp(): Promise<void> {
 		await quantelHTTPTransformerProxy.init()
 	}
 
-	logger.info('Initializing Package Manager (and Expectation Manager)')
+	logger.info('Initializing Package Manager (and Expectation Manager)') // If this log line is changed, make sure that verify-build-win32.mjs is updated too.
 	expectationManager.hookToWorkforce(workforce.getExpectationManagerHook())
 	await connector.init()
 

--- a/shared/packages/api/src/config.ts
+++ b/shared/packages/api/src/config.ts
@@ -118,7 +118,7 @@ const packageManagerArguments = defineArguments({
 	},
 	concurrency: {
 		type: 'number',
-		default: parseInt(process.env.CONCURRENCY || '', 10) || 50,
+		default: parseInt(process.env.CONCURRENCY || '', 10) || undefined,
 		describe: 'How many expectation states can be evaluated at the same time',
 	},
 })
@@ -358,7 +358,7 @@ export interface PackageManagerConfig {
 		watchFiles: boolean
 		noCore: boolean
 		chaosMonkey: boolean
-		concurrency: number
+		concurrency?: number
 	}
 }
 export function getPackageManagerConfig(): PackageManagerConfig {

--- a/shared/packages/api/src/lib.ts
+++ b/shared/packages/api/src/lib.ts
@@ -311,3 +311,14 @@ export function ensureArray<T>(v: T | (T | undefined)[]): T[] {
 export function first<T>(v: T | (T | undefined)[]): T | undefined {
 	return ensureArray(v)[0]
 }
+/** Shallowly remove undefined properties from an object */
+export function removeUndefinedProperties<T extends { [key: string]: unknown } | undefined>(o: T): T {
+	if (!o) return o
+	if (typeof o !== 'object') return o
+
+	const o2: { [key: string]: unknown } = {}
+	for (const [key, value] of Object.entries(o)) {
+		if (value !== undefined) o2[key] = value
+	}
+	return o2 as T
+}

--- a/shared/packages/expectationManager/src/expectationManager.ts
+++ b/shared/packages/expectationManager/src/expectationManager.ts
@@ -22,6 +22,7 @@ import {
 	Statuses,
 	hashObj,
 	setLogLevel,
+	removeUndefinedProperties,
 } from '@sofie-package-manager/api'
 // eslint-disable-next-line node/no-extraneous-import
 import { ExpectedPackageStatusAPI } from '@sofie-automation/shared-lib/dist/package-manager/package'
@@ -133,7 +134,8 @@ export class ExpectationManager extends HelpfulEventEmitter {
 		this.logger = logger.category('ExpectationManager')
 		this.constants = {
 			...getDefaultConstants(),
-			...options?.constants,
+			// Remove undefined properties so that {myConstant: undefined} doesn't overried the default:
+			...removeUndefinedProperties(options?.constants),
 		}
 		this.enableChaosMonkey = options?.chaosMonkey ?? false
 		this.workforceAPI = new WorkforceAPI(this.logger)

--- a/shared/packages/worker/src/worker/accessorHandlers/lib/CachedQuantelGateway.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/lib/CachedQuantelGateway.ts
@@ -1,18 +1,15 @@
 import { ClipSearchQuery, QuantelGateway } from 'tv-automation-quantel-gateway-client'
-import {
-	ClipData,
-	ClipDataSummary,
-	ConnectionDetails,
-	ServerInfo,
-	ZoneInfo,
-} from 'tv-automation-quantel-gateway-client/dist/quantelTypes'
+import { ClipDataSummary, ServerInfo } from 'tv-automation-quantel-gateway-client/dist/quantelTypes'
 
 const DEFAULT_CACHE_EXPIRE = 3000
-const PURGE_CACHE_INTERVAL = 60 * 1000
 
+/**
+ * This is a wrapper for the QuantelGateway class, adding a caching-layer to
+ */
 export class CachedQuantelGateway extends QuantelGateway {
 	private readonly _cache: Map<string, CacheEntry> = new Map()
 	private cacheExpire: number
+	private purgeExpiredCacheTimeout: NodeJS.Timeout | null = null
 
 	constructor(
 		config?:
@@ -25,43 +22,23 @@ export class CachedQuantelGateway extends QuantelGateway {
 	) {
 		super(config)
 		this.cacheExpire = config?.cacheExpire ?? DEFAULT_CACHE_EXPIRE
-		setInterval(() => this.purgeCache(), PURGE_CACHE_INTERVAL)
 	}
-	async connectToISA(ISAUrls: string | string[]): Promise<ConnectionDetails> {
-		const result = this.queryCache<ConnectionDetails>('connectToISA', [ISAUrls])
-		if (result !== undefined) return result
-
-		return this.ensureInCache('connectToISA', [ISAUrls], super.connectToISA(ISAUrls))
+	public purgeCache(): void {
+		this._cache.clear()
 	}
-	async getClip(clipId: number): Promise<ClipData | null> {
-		const result = this.queryCache<ClipData>('getClip', [clipId])
-		if (result !== undefined) return result
-
-		return this.ensureInCache('getClip', [clipId], super.getClip(clipId))
-	}
+	// searchClip() is used often. By caching it, we reduce the load on the server.
 	async searchClip(searchQuery: ClipSearchQuery): Promise<ClipDataSummary[]> {
 		const result = this.queryCache<ClipDataSummary[]>('searchClip', [searchQuery])
 		if (result !== undefined) return result
 
 		return this.ensureInCache('searchClip', [searchQuery], super.searchClip(searchQuery))
 	}
-	async getZones(): Promise<ZoneInfo[]> {
-		const result = this.queryCache<ZoneInfo[]>('getZones', [])
-		if (result !== undefined) return result
-
-		return this.ensureInCache('getZones', [], super.getZones())
-	}
+	// getServer() is used often. By caching it, we reduce the load on the server.
 	async getServer(disableCache?: boolean): Promise<ServerInfo | null> {
 		const result = this.queryCache<ServerInfo>('getServer', [disableCache])
 		if (result !== undefined) return result
 
 		return this.ensureInCache('getServer', [disableCache], super.getServer(disableCache))
-	}
-	async getServers(zoneId?: string): Promise<ServerInfo[]> {
-		const result = this.queryCache<ServerInfo[]>('getServers', [zoneId])
-		if (result !== undefined) return result
-
-		return this.ensureInCache('getServers', [zoneId], super.getServers(zoneId))
 	}
 
 	private queryCache<T>(method: string, args: any[]): Promise<T> | undefined {
@@ -86,7 +63,16 @@ export class CachedQuantelGateway extends QuantelGateway {
 		}
 	}
 
-	private purgeCache() {
+	private triggerPurgeExpiredFromCache() {
+		// Schedule a purging of expired packages
+		if (!this.purgeExpiredCacheTimeout) {
+			this.purgeExpiredCacheTimeout = setTimeout(() => {
+				this.purgeExpiredCacheTimeout = null
+				this.purgeExpiredFromCache()
+			}, this.cacheExpire + 100)
+		}
+	}
+	private purgeExpiredFromCache() {
 		const expiredKeys: string[] = []
 		this._cache.forEach((value, key) => {
 			if (value.timestamp >= Date.now() - this.cacheExpire) return
@@ -99,6 +85,8 @@ export class CachedQuantelGateway extends QuantelGateway {
 	}
 
 	private async ensureInCache<T>(method: string, args: any[], answer: Promise<T>): Promise<T> {
+		this.triggerPurgeExpiredFromCache()
+
 		const cacheKey = this.getCacheKey(method, args)
 
 		try {

--- a/shared/packages/worker/src/worker/accessorHandlers/quantel.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/quantel.ts
@@ -302,7 +302,25 @@ export class QuantelAccessorHandle<Metadata> extends GenericAccessorHandle<Metad
 		// this is a good time to purge the cache so that a later call to searchClip()
 		// returns the updated data.
 		const quantel = await this.getQuantelGateway()
-		quantel.purgeCache()
+
+		const content = this.getContent()
+		if (content.guid) {
+			await quantel.purgeCacheSearchClip({
+				ClipGUID: `"${content.guid}"`,
+			})
+		}
+		if (content.title) {
+			const purgedClips = await quantel.purgeCacheSearchClip({
+				Title: `"${content.title}"`,
+			})
+
+			// Also remove any clips with the same GUI, to handle an edge-case where the title has changed:
+			for (const purgedClip of purgedClips) {
+				await quantel.purgeCacheSearchClip({
+					ClipGUID: `"${purgedClip.ClipGUID}"`,
+				})
+			}
+		}
 	}
 
 	async fetchMetadata(): Promise<Metadata | undefined> {

--- a/tests/internal-tests/package.json
+++ b/tests/internal-tests/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "__build": "rimraf dist && yarn build:main",
         "build:main": "tsc -p tsconfig.json",
-        "test": "jest --runInBand"
+        "test": "jest --runInBand --forceExit"
     },
     "devDependencies": {
         "deep-extend": "^0.6.0",

--- a/tests/internal-tests/src/__mocks__/tv-automation-quantel-gateway-client.ts
+++ b/tests/internal-tests/src/__mocks__/tv-automation-quantel-gateway-client.ts
@@ -2,6 +2,9 @@ import EventEmitter from 'events'
 // eslint-disable-next-line node/no-unpublished-import
 import { Q, ClipSearchQuery } from 'tv-automation-quantel-gateway-client' // note: this is a mocked module
 
+import { Agent as HTTPAgent } from 'http'
+import { Agent as HTTPSAgent } from 'https'
+
 /* eslint-disable no-console */
 
 const client: any = jest.createMockFromModule('tv-automation-quantel-gateway-client')
@@ -37,6 +40,7 @@ interface MockClip {
 let mockClipId = 1000
 
 export function resetMock(): void {
+	if (DEBUG_LOG) console.log('RESET MOCK')
 	mock.servers = [
 		{
 			ident: 1000,
@@ -244,6 +248,7 @@ class QuantelGateway extends EventEmitter {
 			return c.CloneId === clip.CloneId || clip.ClipID
 		})
 		if (existingClip) {
+			if (DEBUG_LOG) console.log('copyClip: already there')
 			// already there:
 			return {
 				zoneID: zoneID,
@@ -262,6 +267,8 @@ class QuantelGateway extends EventEmitter {
 			newClip.CloneId = clip.CloneId || clip.ClipID
 
 			toPool.clips.push(newClip)
+
+			if (DEBUG_LOG) console.log('copyClip: add', newClip)
 
 			return {
 				zoneID: zoneID,
@@ -304,6 +311,16 @@ class QuantelGateway extends EventEmitter {
 				PoolID: result.pool.id,
 			}
 		})
+	}
+
+	getHTTPAgents(): Readonly<{
+		http: HTTPAgent
+		https: HTTPSAgent
+	}> {
+		return {
+			http: { sockets: [] },
+			https: { sockets: [] },
+		} as any
 	}
 }
 client.QuantelGateway = QuantelGateway

--- a/tests/internal-tests/src/__tests__/basic.spec.ts
+++ b/tests/internal-tests/src/__tests__/basic.spec.ts
@@ -9,7 +9,7 @@ import type * as fsMockType from '../__mocks__/fs'
 import type * as WNDType from '../__mocks__/windows-network-drive'
 import type * as QGatewayClientType from '../__mocks__/tv-automation-quantel-gateway-client'
 import { prepareTestEnviromnent, TestEnviromnent } from './lib/setupEnv'
-import { waitTime } from './lib/lib'
+import { waitUntil } from './lib/lib'
 import {
 	getFileShareSource,
 	getLocalSource,
@@ -22,9 +22,9 @@ jest.mock('child_process')
 jest.mock('windows-network-drive')
 jest.mock('tv-automation-quantel-gateway-client')
 
-const fs = (fsOrg as any) as typeof fsMockType
-const WND = (WNDOrg as any) as typeof WNDType
-const QGatewayClient = (QGatewayClientOrg as any) as typeof QGatewayClientType
+const fs = fsOrg as any as typeof fsMockType
+const WND = WNDOrg as any as typeof WNDType
+const QGatewayClient = QGatewayClientOrg as any as typeof QGatewayClientType
 
 const fsStat = promisify(fs.stat)
 
@@ -78,15 +78,14 @@ describe('Basic', () => {
 			}),
 		})
 
-		await waitTime(env.WAIT_JOB_TIME)
-
-		// Expect the copy to have completed by now:
-
-		expect(env.containerStatuses['target0']).toBeTruthy()
-		expect(env.containerStatuses['target0'].packages['package0']).toBeTruthy()
-		expect(env.containerStatuses['target0'].packages['package0'].packageStatus?.status).toEqual(
-			ExpectedPackageStatusAPI.PackageContainerPackageStatusStatus.READY
-		)
+		// Wait for the job to complete:
+		await waitUntil(() => {
+			expect(env.containerStatuses['target0']).toBeTruthy()
+			expect(env.containerStatuses['target0'].packages['package0']).toBeTruthy()
+			expect(env.containerStatuses['target0'].packages['package0'].packageStatus?.status).toEqual(
+				ExpectedPackageStatusAPI.PackageContainerPackageStatusStatus.READY
+			)
+		}, env.WAIT_JOB_TIME)
 
 		expect(env.expectationStatuses['copy0'].statusInfo.status).toEqual('fulfilled')
 
@@ -127,17 +126,14 @@ describe('Basic', () => {
 			}),
 		})
 
-		await waitTime(env.WAIT_JOB_TIME)
-
-		// Expect the copy to have completed by now:
-
-		// console.log(fs.__printAllFiles())
-
-		expect(env.containerStatuses['target1']).toBeTruthy()
-		expect(env.containerStatuses['target1'].packages['package0']).toBeTruthy()
-		expect(env.containerStatuses['target1'].packages['package0'].packageStatus?.status).toEqual(
-			ExpectedPackageStatusAPI.PackageContainerPackageStatusStatus.READY
-		)
+		// Wait for the job to complete:
+		await waitUntil(() => {
+			expect(env.containerStatuses['target1']).toBeTruthy()
+			expect(env.containerStatuses['target1'].packages['package0']).toBeTruthy()
+			expect(env.containerStatuses['target1'].packages['package0'].packageStatus?.status).toEqual(
+				ExpectedPackageStatusAPI.PackageContainerPackageStatusStatus.READY
+			)
+		}, env.WAIT_JOB_TIME)
 
 		expect(env.expectationStatuses['copy0'].statusInfo.status).toEqual('fulfilled')
 
@@ -180,15 +176,14 @@ describe('Basic', () => {
 			}),
 		})
 
-		await waitTime(env.WAIT_JOB_TIME)
-
-		// Expect the copy to have completed by now:
-
-		expect(env.containerStatuses['target1']).toBeTruthy()
-		expect(env.containerStatuses['target1'].packages['package0']).toBeTruthy()
-		expect(env.containerStatuses['target1'].packages['package0'].packageStatus?.status).toEqual(
-			ExpectedPackageStatusAPI.PackageContainerPackageStatusStatus.READY
-		)
+		// Wait for the job to complete:
+		await waitUntil(() => {
+			expect(env.containerStatuses['target1']).toBeTruthy()
+			expect(env.containerStatuses['target1'].packages['package0']).toBeTruthy()
+			expect(env.containerStatuses['target1'].packages['package0'].packageStatus?.status).toEqual(
+				ExpectedPackageStatusAPI.PackageContainerPackageStatusStatus.READY
+			)
+		}, env.WAIT_JOB_TIME)
 
 		expect(env.expectationStatuses['copy0'].statusInfo.status).toEqual('fulfilled')
 

--- a/tests/internal-tests/src/__tests__/lib/lib.ts
+++ b/tests/internal-tests/src/__tests__/lib/lib.ts
@@ -1,3 +1,22 @@
-export function waitTime(ms: number) {
+export function waitTime(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms))
+}
+/**
+ * Executes {expectFcn} intermittently until it doesn't throw anymore.
+ * Waits up to {maxWaitTime} ms, then throws the latest error.
+ * Useful in unit-tests as a way to wait until a predicate is fulfilled.
+ */
+export async function waitUntil(expectFcn: () => void, maxWaitTime: number): Promise<void> {
+	const startTime = Date.now()
+	while (true) {
+		await waitTime(100)
+		try {
+			expectFcn()
+			return
+		} catch (err) {
+			let waitedTime = Date.now() - startTime
+			if (waitedTime > maxWaitTime) throw err
+			// else ignore error and try again later
+		}
+	}
 }

--- a/tests/internal-tests/src/__tests__/quantel.spec.ts
+++ b/tests/internal-tests/src/__tests__/quantel.spec.ts
@@ -1,10 +1,10 @@
 // eslint-disable-next-line node/no-extraneous-import
 import { ExpectedPackageStatusAPI } from '@sofie-automation/shared-lib/dist/package-manager/package'
 import * as QGatewayClientOrg from 'tv-automation-quantel-gateway-client'
-import { Expectation, literal } from '@sofie-package-manager/api'
+import { Expectation, literal, waitTime } from '@sofie-package-manager/api'
 import type * as QGatewayClientType from '../__mocks__/tv-automation-quantel-gateway-client'
 import { prepareTestEnviromnent, TestEnviromnent } from './lib/setupEnv'
-import { waitTime } from './lib/lib'
+import { waitUntil } from './lib/lib'
 import { getQuantelSource, getQuantelTarget } from './lib/containers'
 jest.mock('child_process')
 jest.mock('tv-automation-quantel-gateway-client')
@@ -55,15 +55,14 @@ describe('Quantel', () => {
 			}),
 		})
 
-		await waitTime(env.WAIT_JOB_TIME)
-
-		// Expect the copy to have completed by now:
-
-		expect(env.containerStatuses['target1']).toBeTruthy()
-		expect(env.containerStatuses['target1'].packages['package0']).toBeTruthy()
-		expect(env.containerStatuses['target1'].packages['package0'].packageStatus?.status).toEqual(
-			ExpectedPackageStatusAPI.PackageContainerPackageStatusStatus.READY
-		)
+		// Wait for the job to complete:
+		await waitUntil(() => {
+			expect(env.containerStatuses['target1']).toBeTruthy()
+			expect(env.containerStatuses['target1'].packages['package0']).toBeTruthy()
+			expect(env.containerStatuses['target1'].packages['package0'].packageStatus?.status).toEqual(
+				ExpectedPackageStatusAPI.PackageContainerPackageStatusStatus.READY
+			)
+		}, env.WAIT_JOB_TIME)
 
 		expect(env.expectationStatuses['copy0'].statusInfo.status).toEqual('fulfilled')
 
@@ -111,15 +110,14 @@ describe('Quantel', () => {
 			}),
 		})
 
-		await waitTime(env.WAIT_JOB_TIME)
-
-		// Expect the copy to have completed by now:
-
-		expect(env.containerStatuses['target1']).toBeTruthy()
-		expect(env.containerStatuses['target1'].packages['package0']).toBeTruthy()
-		expect(env.containerStatuses['target1'].packages['package0'].packageStatus?.status).toEqual(
-			ExpectedPackageStatusAPI.PackageContainerPackageStatusStatus.READY
-		)
+		// Wait for the job to complete:
+		await waitUntil(() => {
+			expect(env.containerStatuses['target1']).toBeTruthy()
+			expect(env.containerStatuses['target1'].packages['package0']).toBeTruthy()
+			expect(env.containerStatuses['target1'].packages['package0'].packageStatus?.status).toEqual(
+				ExpectedPackageStatusAPI.PackageContainerPackageStatusStatus.READY
+			)
+		}, env.WAIT_JOB_TIME)
 
 		expect(env.expectationStatuses['copy0'].statusInfo.status).toEqual('fulfilled')
 
@@ -202,9 +200,8 @@ describe('Quantel', () => {
 			}),
 		})
 
+		// Wait a little while, to ensure that an evaulation has passed:
 		await waitTime(env.WAIT_JOB_TIME)
-
-		// Expect the job to have completed by now:
 
 		expect(QGatewayClient.QuantelGatewayInstances.length).toBeGreaterThanOrEqual(1)
 		for (const instance of QGatewayClient.QuantelGatewayInstances) {


### PR DESCRIPTION
This PR fixes a few issues:

* don't set `concurrency` as a CLI default value. Instead allow it to be undefined so that the default value (in constants.ts) takes effect.
* Improve unit tests to make them more robust.
* update quantel-gateway-client mock
* rework CachedQuantelGateway, fixing a few issues:
  * Add a `purgeCache()` - call from quantel after a copy has finished, so that the copied clip is always reflected to later calls to `searchClip()`
  * Remove a few seldom-used methods from cache (`connectToISA`, `getClip`, `getZones`, `getServers`)
  * change the scheduling of purging expired items from cache, so that it is triggered (using setTimeout) by an activity rather than on an interval. This is done because there currently wasn't any way to clear the setInterval.


Most of these things are affecting unit-test only, but the `purgeCache`-fix might fix a potential bug in production where a job could get stuck in a loop `working->fulfilled->(cache-is-old-so-the-clip-doesnt-seem-to-exist)->new`
