### PR TITLE
Fix: sourceExists

### DIFF
--- a/shared/packages/api/src/worker.ts
+++ b/shared/packages/api/src/worker.ts
@@ -19,10 +19,14 @@ export type ReturnTypeGetCostFortExpectation = {
 export type ReturnTypeIsExpectationReadyToStartWorkingOn =
 	| {
 			ready: true
-			sourceExists?: boolean
 	  }
 	| {
 			ready: false
+			/**
+			 * true indicates that a source exists,
+			 * false indicates that a source does not exist,
+			 * undefined means unknown
+			 */
 			sourceExists?: boolean
 			isWaitingForAnother?: boolean
 			reason: Reason

--- a/shared/packages/expectationManager/src/evaluationRunner/evaluateExpectationStates/waiting.ts
+++ b/shared/packages/expectationManager/src/evaluationRunner/evaluateExpectationStates/waiting.ts
@@ -45,7 +45,8 @@ export async function evaluateExpectationStateWaiting({
 				)
 
 				const newStatus: Partial<TrackedExpectation['status']> = {}
-				if (readyToStart.sourceExists !== undefined) newStatus.sourceExists = readyToStart.sourceExists
+				const sourceExists = readyToStart.ready || readyToStart.sourceExists
+				if (sourceExists !== undefined) newStatus.sourceExists = sourceExists
 
 				if (readyToStart.ready) {
 					tracker.trackedExpectationAPI.updateTrackedExpectationStatus(trackedExp, {

--- a/shared/packages/worker/src/worker/accessorHandlers/atem.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/atem.ts
@@ -128,6 +128,7 @@ export class ATEMAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 		if (!atem.state?.media.clipPool || !atem.state?.media.stillPool) {
 			return {
 				success: false,
+				packageExists: false,
 				reason: {
 					user: `ATEM media pools are inaccessible`,
 					tech: `ATEM media pools are inaccessible`,

--- a/shared/packages/worker/src/worker/accessorHandlers/atem.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/atem.ts
@@ -3,8 +3,13 @@ import {
 	PackageReadInfo,
 	PackageReadStream,
 	PutPackageHandler,
-	AccessorHandlerResult,
 	SetupPackageContainerMonitorsResult,
+	AccessorHandlerCheckHandleReadResult,
+	AccessorHandlerCheckHandleWriteResult,
+	AccessorHandlerCheckPackageContainerWriteAccessResult,
+	AccessorHandlerCheckPackageReadAccessResult,
+	AccessorHandlerTryPackageReadResult,
+	AccessorHandlerRunCronJobResult,
 } from './genericHandle'
 import { Expectation, Accessor, AccessorOnPackage } from '@sofie-package-manager/api'
 import { GenericWorker } from '../worker'
@@ -60,7 +65,7 @@ export class ATEMAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 		}
 		return this.worker.accessorCache['atem'] as Atem
 	}
-	checkHandleRead(): AccessorHandlerResult {
+	checkHandleRead(): AccessorHandlerCheckHandleReadResult {
 		if (!this.accessor.allowRead) {
 			return {
 				success: false,
@@ -72,7 +77,7 @@ export class ATEMAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 		}
 		return this.checkAccessor()
 	}
-	checkHandleWrite(): AccessorHandlerResult {
+	checkHandleWrite(): AccessorHandlerCheckHandleWriteResult {
 		if (!this.accessor.allowWrite) {
 			return {
 				success: false,
@@ -84,7 +89,7 @@ export class ATEMAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 		}
 		return this.checkAccessor()
 	}
-	async checkPackageReadAccess(): Promise<AccessorHandlerResult> {
+	async checkPackageReadAccess(): Promise<AccessorHandlerCheckPackageReadAccessResult> {
 		// Check if the package exists:
 		const atem = await this.getAtem()
 		if (!atem.state) {
@@ -118,7 +123,7 @@ export class ATEMAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 			},
 		}
 	}
-	async tryPackageRead(): Promise<AccessorHandlerResult> {
+	async tryPackageRead(): Promise<AccessorHandlerTryPackageReadResult> {
 		const atem = await this.getAtem()
 		if (!atem.state?.media.clipPool || !atem.state?.media.stillPool) {
 			return {
@@ -132,7 +137,7 @@ export class ATEMAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 
 		return { success: true }
 	}
-	async checkPackageContainerWriteAccess(): Promise<AccessorHandlerResult> {
+	async checkPackageContainerWriteAccess(): Promise<AccessorHandlerCheckPackageContainerWriteAccessResult> {
 		const atem = await this.getAtem()
 		if (atem.status === AtemConnectionStatus.CONNECTED && atem.state) {
 			return { success: true }
@@ -382,7 +387,7 @@ export class ATEMAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 	async removeMetadata(): Promise<void> {
 		// Not supported
 	}
-	async runCronJob(): Promise<AccessorHandlerResult> {
+	async runCronJob(): Promise<AccessorHandlerRunCronJobResult> {
 		return {
 			success: true,
 		} // not applicable
@@ -397,7 +402,7 @@ export class ATEMAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 		} // not applicable
 	}
 
-	private checkAccessor(): AccessorHandlerResult {
+	private checkAccessor(): AccessorHandlerCheckHandleWriteResult {
 		if (this.accessor.type !== Accessor.AccessType.ATEM_MEDIA_STORE) {
 			return {
 				success: false,

--- a/shared/packages/worker/src/worker/accessorHandlers/atem.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/atem.ts
@@ -23,6 +23,7 @@ import * as path from 'path'
 import { promisify } from 'util'
 import { UniversalVersion } from '../workers/windowsWorker/lib/lib'
 import { MAX_EXEC_BUFFER } from '../lib/lib'
+import { defaultCheckHandleRead, defaultCheckHandleWrite } from './lib/lib'
 
 const fsReadFile = promisify(fs.readFile)
 
@@ -66,27 +67,13 @@ export class ATEMAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 		return this.worker.accessorCache['atem'] as Atem
 	}
 	checkHandleRead(): AccessorHandlerCheckHandleReadResult {
-		if (!this.accessor.allowRead) {
-			return {
-				success: false,
-				reason: {
-					user: `Not allowed to read`,
-					tech: `Not allowed to read`,
-				},
-			}
-		}
+		const defaultResult = defaultCheckHandleRead(this.accessor)
+		if (defaultResult) return defaultResult
 		return this.checkAccessor()
 	}
 	checkHandleWrite(): AccessorHandlerCheckHandleWriteResult {
-		if (!this.accessor.allowWrite) {
-			return {
-				success: false,
-				reason: {
-					user: `Not allowed to write`,
-					tech: `Not allowed to write`,
-				},
-			}
-		}
+		const defaultResult = defaultCheckHandleWrite(this.accessor)
+		if (defaultResult) return defaultResult
 		return this.checkAccessor()
 	}
 	async checkPackageReadAccess(): Promise<AccessorHandlerCheckPackageReadAccessResult> {

--- a/shared/packages/worker/src/worker/accessorHandlers/corePackageInfo.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/corePackageInfo.ts
@@ -1,8 +1,13 @@
 import {
+	AccessorHandlerCheckHandleReadResult,
+	AccessorHandlerCheckHandleWriteResult,
+	AccessorHandlerCheckPackageContainerWriteAccessResult,
+	AccessorHandlerCheckPackageReadAccessResult,
+	AccessorHandlerRunCronJobResult,
+	AccessorHandlerTryPackageReadResult,
 	GenericAccessorHandle,
 	PackageReadInfo,
 	PutPackageHandler,
-	AccessorHandlerResult,
 	SetupPackageContainerMonitorsResult,
 } from './genericHandle'
 import { Accessor, AccessorOnPackage, hashObj, Expectation, Reason } from '@sofie-package-manager/api'
@@ -33,15 +38,15 @@ export class CorePackageInfoAccessorHandle<Metadata> extends GenericAccessorHand
 	static doYouSupportAccess(): boolean {
 		return true // always has access
 	}
-	checkHandleRead(): AccessorHandlerResult {
+	checkHandleRead(): AccessorHandlerCheckHandleReadResult {
 		// Note: We assume that we always have write access here, no need to check this.accessor.allowRead
 		return this.checkAccessor()
 	}
-	checkHandleWrite(): AccessorHandlerResult {
+	checkHandleWrite(): AccessorHandlerCheckHandleWriteResult {
 		// Note: We assume that we always have write access here, no need to check this.accessor.allowWrite
 		return this.checkAccessor()
 	}
-	private checkAccessor(): AccessorHandlerResult {
+	private checkAccessor(): AccessorHandlerCheckHandleWriteResult {
 		if (this.accessor.type !== Accessor.AccessType.CORE_PACKAGE_INFO) {
 			return {
 				success: false,
@@ -53,15 +58,15 @@ export class CorePackageInfoAccessorHandle<Metadata> extends GenericAccessorHand
 		}
 		return { success: true }
 	}
-	async checkPackageReadAccess(): Promise<AccessorHandlerResult> {
+	async checkPackageReadAccess(): Promise<AccessorHandlerCheckPackageReadAccessResult> {
 		// todo: add a check here?
 		return { success: true }
 	}
-	async tryPackageRead(): Promise<AccessorHandlerResult> {
+	async tryPackageRead(): Promise<AccessorHandlerTryPackageReadResult> {
 		// not needed
 		return { success: true }
 	}
-	async checkPackageContainerWriteAccess(): Promise<AccessorHandlerResult> {
+	async checkPackageContainerWriteAccess(): Promise<AccessorHandlerCheckPackageContainerWriteAccessResult> {
 		// todo: add a check here?
 		return { success: true }
 	}
@@ -108,7 +113,7 @@ export class CorePackageInfoAccessorHandle<Metadata> extends GenericAccessorHand
 	async removeMetadata(): Promise<void> {
 		// Not applicable
 	}
-	async runCronJob(): Promise<AccessorHandlerResult> {
+	async runCronJob(): Promise<AccessorHandlerRunCronJobResult> {
 		return {
 			success: true,
 		} // not applicable

--- a/shared/packages/worker/src/worker/accessorHandlers/fileShare.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/fileShare.ts
@@ -172,16 +172,19 @@ export class FileShareAccessorHandle<Metadata> extends GenericFileAccessorHandle
 			if (err && (err as any).code === 'EBUSY') {
 				return {
 					success: false,
+					packageExists: true,
 					reason: { user: `Not able to read file (file is busy)`, tech: `${stringifyError(err, true)}` },
 				}
 			} else if (err && (err as any).code === 'ENOENT') {
 				return {
 					success: false,
+					packageExists: false,
 					reason: { user: `File does not exist`, tech: `${stringifyError(err, true)}` },
 				}
 			} else {
 				return {
 					success: false,
+					packageExists: false,
 					reason: { user: `Not able to read file`, tech: `${stringifyError(err, true)}` },
 				}
 			}

--- a/shared/packages/worker/src/worker/accessorHandlers/fileShare.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/fileShare.ts
@@ -28,6 +28,7 @@ import { exec } from 'child_process'
 import { FileShareAccessorHandleType, GenericFileAccessorHandle } from './lib/FileHandler'
 import { MonitorInProgress } from '../lib/monitorInProgress'
 import { MAX_EXEC_BUFFER } from '../lib/lib'
+import { defaultCheckHandleRead, defaultCheckHandleWrite } from './lib/lib'
 
 const fsStat = promisify(fs.stat)
 const fsAccess = promisify(fs.access)
@@ -102,27 +103,13 @@ export class FileShareAccessorHandle<Metadata> extends GenericFileAccessorHandle
 		return !accessor.networkId || worker.agentAPI.location.localNetworkIds.includes(accessor.networkId)
 	}
 	checkHandleRead(): AccessorHandlerCheckHandleReadResult {
-		if (!this.accessor.allowRead) {
-			return {
-				success: false,
-				reason: {
-					user: `Not allowed to read`,
-					tech: `Not allowed to read`,
-				},
-			}
-		}
+		const defaultResult = defaultCheckHandleRead(this.accessor)
+		if (defaultResult) return defaultResult
 		return this.checkAccessor()
 	}
 	checkHandleWrite(): AccessorHandlerCheckHandleWriteResult {
-		if (!this.accessor.allowWrite) {
-			return {
-				success: false,
-				reason: {
-					user: `Not allowed to write`,
-					tech: `Not allowed to write`,
-				},
-			}
-		}
+		const defaultResult = defaultCheckHandleWrite(this.accessor)
+		if (defaultResult) return defaultResult
 		return this.checkAccessor()
 	}
 	private checkAccessor(): AccessorHandlerCheckHandleWriteResult {

--- a/shared/packages/worker/src/worker/accessorHandlers/genericHandle.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/genericHandle.ts
@@ -155,7 +155,12 @@ export type AccessorHandlerResultGeneric = AccessorHandlerResultSuccess | Access
 export type AccessorHandlerCheckHandleReadResult = AccessorHandlerResultGeneric
 export type AccessorHandlerCheckHandleWriteResult = AccessorHandlerCheckHandleReadResult
 export type AccessorHandlerCheckPackageReadAccessResult = AccessorHandlerResultGeneric
-export type AccessorHandlerTryPackageReadResult = AccessorHandlerResultSuccess | (AccessorHandlerResultBad & {})
+export type AccessorHandlerTryPackageReadResult =
+	| AccessorHandlerResultSuccess
+	| (AccessorHandlerResultBad & {
+			/** If true, indicates that the package exists at all */
+			packageExists: boolean
+	  })
 export type AccessorHandlerCheckPackageContainerWriteAccessResult = AccessorHandlerResultGeneric
 export type AccessorHandlerRunCronJobResult = Promise<AccessorHandlerResultGeneric>
 export type SetupPackageContainerMonitorsResult =

--- a/shared/packages/worker/src/worker/accessorHandlers/genericHandle.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/genericHandle.ts
@@ -29,30 +29,30 @@ export abstract class GenericAccessorHandle<Metadata> {
 	 * Checks if there are any issues with the properties in the accessor or content for being able to read
 	 * @returns undefined if all is OK / string with error message
 	 */
-	abstract checkHandleRead(): AccessorHandlerResult
+	abstract checkHandleRead(): AccessorHandlerCheckHandleReadResult
 	/**
 	 * Checks if there are any issues with the properties in the accessor or content for being able to write
 	 * @returns undefined if all is OK / string with error message
 	 */
-	abstract checkHandleWrite(): AccessorHandlerResult
+	abstract checkHandleWrite(): AccessorHandlerCheckHandleWriteResult
 	/**
 	 * Checks if Accesor has access to the Package, for reading.
 	 * Errors from this method are related to access/permission issues, or that the package doesn't exist.
 	 * @returns undefined if all is OK / string with error message
 	 */
-	abstract checkPackageReadAccess(): Promise<AccessorHandlerResult>
+	abstract checkPackageReadAccess(): Promise<AccessorHandlerCheckPackageReadAccessResult>
 
 	/**
 	 * Do a check if it actually is possible to access the package.
 	 * Errors from this method are related to the actual access of the package (such as resource is busy).
 	 * @returns undefined if all is OK / string with error message
 	 */
-	abstract tryPackageRead(): Promise<AccessorHandlerResult>
+	abstract tryPackageRead(): Promise<AccessorHandlerTryPackageReadResult>
 	/**
 	 * Checks if the PackageContainer can be written to
 	 * @returns undefined if all is OK / string with error message
 	 */
-	abstract checkPackageContainerWriteAccess(): Promise<AccessorHandlerResult>
+	abstract checkPackageContainerWriteAccess(): Promise<AccessorHandlerCheckPackageContainerWriteAccessResult>
 	/**
 	 * Extracts and returns the version from the package
 	 * @returns the vesion of the package
@@ -103,7 +103,7 @@ export abstract class GenericAccessorHandle<Metadata> {
 	 * Performs a cronjob on the Package container
 	 * @returns undefined if all is OK / string with error message
 	 */
-	abstract runCronJob(packageContainerExp: PackageContainerExpectation): Promise<AccessorHandlerResult>
+	abstract runCronJob(packageContainerExp: PackageContainerExpectation): Promise<AccessorHandlerRunCronJobResult>
 	/**
 	 * Setup monitors on the Package container
 	 * @returns undefined if all is OK / string with error message
@@ -137,28 +137,32 @@ export abstract class GenericAccessorHandle<Metadata> {
 	}
 }
 
+/** Default result returned from most accessorHandler-methods when the result was a success */
+type AccessorHandlerResultSuccess = {
+	/** Whether the action was successful or not */
+	success: true
+}
+/** Default result returned from most accessorHandler-methods when the result was NOT a success */
+type AccessorHandlerResultBad = {
+	/** Whether the action was successful or not */
+	success: false
+	/** The reason why the action wasn't successful*/
+	reason: Reason
+}
 /** Default result returned from most accessorHandler-methods */
-export type AccessorHandlerResult =
-	| {
-			/** Whether the action was successful or not */
-			success: true
-	  }
-	| {
-			/** Whether the action was successful or not */
-			success: false
-			/** If the action isn't successful, the reason why */
-			reason: Reason
-	  }
+export type AccessorHandlerResultGeneric = AccessorHandlerResultSuccess | AccessorHandlerResultBad
 
+export type AccessorHandlerCheckHandleReadResult = AccessorHandlerResultGeneric
+export type AccessorHandlerCheckHandleWriteResult = AccessorHandlerCheckHandleReadResult
+export type AccessorHandlerCheckPackageReadAccessResult = AccessorHandlerResultGeneric
+export type AccessorHandlerTryPackageReadResult = AccessorHandlerResultSuccess | (AccessorHandlerResultBad & {})
+export type AccessorHandlerCheckPackageContainerWriteAccessResult = AccessorHandlerResultGeneric
+export type AccessorHandlerRunCronJobResult = Promise<AccessorHandlerResultGeneric>
 export type SetupPackageContainerMonitorsResult =
-	| {
-			success: true
+	| (AccessorHandlerResultSuccess & {
 			monitors: { [monitorId: string]: MonitorInProgress }
-	  }
-	| {
-			success: false
-			reason: Reason
-	  }
+	  })
+	| AccessorHandlerResultBad
 /**
  * A class emitted from putPackageStream() and putPackageInfo(), used to signal the progression of an ongoing write operation.
  * Users of this class are required to emit the events 'error' on error and 'close' upon completion

--- a/shared/packages/worker/src/worker/accessorHandlers/http.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/http.ts
@@ -24,6 +24,7 @@ import { fetchWithController, fetchWithTimeout } from './lib/fetch'
 import FormData from 'form-data'
 import { MonitorInProgress } from '../lib/monitorInProgress'
 import { joinUrls } from './lib/pathJoin'
+import { defaultCheckHandleRead, defaultCheckHandleWrite } from './lib/lib'
 
 /** Accessor handle for accessing files in a local folder */
 export class HTTPAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata> {
@@ -58,27 +59,13 @@ export class HTTPAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 		return !accessor.networkId || worker.agentAPI.location.localNetworkIds.includes(accessor.networkId)
 	}
 	checkHandleRead(): AccessorHandlerCheckHandleReadResult {
-		if (!this.accessor.allowRead) {
-			return {
-				success: false,
-				reason: {
-					user: `Not allowed to read`,
-					tech: `Not allowed to read`,
-				},
-			}
-		}
+		const defaultResult = defaultCheckHandleRead(this.accessor)
+		if (defaultResult) return defaultResult
 		return this.checkAccessor()
 	}
 	checkHandleWrite(): AccessorHandlerCheckHandleWriteResult {
-		if (!this.accessor.allowWrite) {
-			return {
-				success: false,
-				reason: {
-					user: `Not allowed to write`,
-					tech: `Not allowed to write`,
-				},
-			}
-		}
+		const defaultResult = defaultCheckHandleWrite(this.accessor)
+		if (defaultResult) return defaultResult
 		return this.checkAccessor()
 	}
 	async checkPackageReadAccess(): Promise<AccessorHandlerCheckPackageReadAccessResult> {

--- a/shared/packages/worker/src/worker/accessorHandlers/http.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/http.ts
@@ -3,8 +3,13 @@ import {
 	PackageReadInfo,
 	PackageReadStream,
 	PutPackageHandler,
-	AccessorHandlerResult,
 	SetupPackageContainerMonitorsResult,
+	AccessorHandlerRunCronJobResult,
+	AccessorHandlerCheckHandleReadResult,
+	AccessorHandlerCheckHandleWriteResult,
+	AccessorHandlerCheckPackageContainerWriteAccessResult,
+	AccessorHandlerCheckPackageReadAccessResult,
+	AccessorHandlerTryPackageReadResult,
 } from './genericHandle'
 import {
 	Accessor,
@@ -52,7 +57,7 @@ export class HTTPAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 		const accessor = accessor0 as AccessorOnPackage.HTTP
 		return !accessor.networkId || worker.agentAPI.location.localNetworkIds.includes(accessor.networkId)
 	}
-	checkHandleRead(): AccessorHandlerResult {
+	checkHandleRead(): AccessorHandlerCheckHandleReadResult {
 		if (!this.accessor.allowRead) {
 			return {
 				success: false,
@@ -64,7 +69,7 @@ export class HTTPAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 		}
 		return this.checkAccessor()
 	}
-	checkHandleWrite(): AccessorHandlerResult {
+	checkHandleWrite(): AccessorHandlerCheckHandleWriteResult {
 		if (!this.accessor.allowWrite) {
 			return {
 				success: false,
@@ -76,7 +81,7 @@ export class HTTPAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 		}
 		return this.checkAccessor()
 	}
-	async checkPackageReadAccess(): Promise<AccessorHandlerResult> {
+	async checkPackageReadAccess(): Promise<AccessorHandlerCheckPackageReadAccessResult> {
 		const header = await this.fetchHeader()
 
 		if (header.status >= 400) {
@@ -90,13 +95,13 @@ export class HTTPAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 		}
 		return { success: true }
 	}
-	async tryPackageRead(): Promise<AccessorHandlerResult> {
+	async tryPackageRead(): Promise<AccessorHandlerTryPackageReadResult> {
 		// TODO: Do a HEAD request?
 		// 204 or 404 is "not found"
 		// Access-Control-Allow-Methods should contain GET
 		return { success: true }
 	}
-	async checkPackageContainerWriteAccess(): Promise<AccessorHandlerResult> {
+	async checkPackageContainerWriteAccess(): Promise<AccessorHandlerCheckPackageContainerWriteAccessResult> {
 		// todo: how to check this?
 		return { success: true }
 	}
@@ -150,7 +155,7 @@ export class HTTPAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 		// Not supported
 	}
 
-	async runCronJob(packageContainerExp: PackageContainerExpectation): Promise<AccessorHandlerResult> {
+	async runCronJob(packageContainerExp: PackageContainerExpectation): Promise<AccessorHandlerRunCronJobResult> {
 		let badReason: Reason | null = null
 		const cronjobs = Object.keys(packageContainerExp.cronjobs) as (keyof PackageContainerExpectation['cronjobs'])[]
 		for (const cronjob of cronjobs) {
@@ -195,7 +200,7 @@ export class HTTPAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 		return joinUrls(this.baseUrl, this.path)
 	}
 
-	private checkAccessor(): AccessorHandlerResult {
+	private checkAccessor(): AccessorHandlerCheckHandleWriteResult {
 		if (this.accessor.type !== Accessor.AccessType.HTTP) {
 			return {
 				success: false,

--- a/shared/packages/worker/src/worker/accessorHandlers/httpProxy.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/httpProxy.ts
@@ -3,8 +3,13 @@ import {
 	PackageReadInfo,
 	PackageReadStream,
 	PutPackageHandler,
-	AccessorHandlerResult,
 	SetupPackageContainerMonitorsResult,
+	AccessorHandlerRunCronJobResult,
+	AccessorHandlerCheckHandleReadResult,
+	AccessorHandlerCheckHandleWriteResult,
+	AccessorHandlerCheckPackageContainerWriteAccessResult,
+	AccessorHandlerCheckPackageReadAccessResult,
+	AccessorHandlerTryPackageReadResult,
 } from './genericHandle'
 import {
 	Accessor,
@@ -52,7 +57,7 @@ export class HTTPProxyAccessorHandle<Metadata> extends GenericAccessorHandle<Met
 		const accessor = accessor0 as AccessorOnPackage.HTTP
 		return !accessor.networkId || worker.agentAPI.location.localNetworkIds.includes(accessor.networkId)
 	}
-	checkHandleRead(): AccessorHandlerResult {
+	checkHandleRead(): AccessorHandlerCheckHandleReadResult {
 		if (!this.accessor.allowRead) {
 			return {
 				success: false,
@@ -64,7 +69,7 @@ export class HTTPProxyAccessorHandle<Metadata> extends GenericAccessorHandle<Met
 		}
 		return this.checkAccessor()
 	}
-	checkHandleWrite(): AccessorHandlerResult {
+	checkHandleWrite(): AccessorHandlerCheckHandleWriteResult {
 		if (!this.accessor.allowWrite) {
 			return {
 				success: false,
@@ -76,7 +81,7 @@ export class HTTPProxyAccessorHandle<Metadata> extends GenericAccessorHandle<Met
 		}
 		return this.checkAccessor()
 	}
-	async checkPackageReadAccess(): Promise<AccessorHandlerResult> {
+	async checkPackageReadAccess(): Promise<AccessorHandlerCheckPackageReadAccessResult> {
 		const header = await this.fetchHeader()
 
 		if (header.status >= 400) {
@@ -90,11 +95,11 @@ export class HTTPProxyAccessorHandle<Metadata> extends GenericAccessorHandle<Met
 		}
 		return { success: true }
 	}
-	async tryPackageRead(): Promise<AccessorHandlerResult> {
+	async tryPackageRead(): Promise<AccessorHandlerTryPackageReadResult> {
 		// TODO: how to do this?
 		return { success: true }
 	}
-	async checkPackageContainerWriteAccess(): Promise<AccessorHandlerResult> {
+	async checkPackageContainerWriteAccess(): Promise<AccessorHandlerCheckPackageContainerWriteAccessResult> {
 		// todo: how to check this?
 		return { success: true }
 	}
@@ -177,7 +182,7 @@ export class HTTPProxyAccessorHandle<Metadata> extends GenericAccessorHandle<Met
 		await this.deletePackageIfExists(this.getMetadataPath(this.fullUrl))
 	}
 
-	async runCronJob(packageContainerExp: PackageContainerExpectation): Promise<AccessorHandlerResult> {
+	async runCronJob(packageContainerExp: PackageContainerExpectation): Promise<AccessorHandlerRunCronJobResult> {
 		let badReason: Reason | null = null
 		const cronjobs = Object.keys(packageContainerExp.cronjobs) as (keyof PackageContainerExpectation['cronjobs'])[]
 		for (const cronjob of cronjobs) {
@@ -221,7 +226,7 @@ export class HTTPProxyAccessorHandle<Metadata> extends GenericAccessorHandle<Met
 		return joinUrls(this.baseUrl, this.filePath)
 	}
 
-	private checkAccessor(): AccessorHandlerResult {
+	private checkAccessor(): AccessorHandlerCheckHandleWriteResult {
 		if (this.accessor.type !== Accessor.AccessType.HTTP_PROXY) {
 			return {
 				success: false,

--- a/shared/packages/worker/src/worker/accessorHandlers/httpProxy.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/httpProxy.ts
@@ -24,6 +24,7 @@ import FormData from 'form-data'
 import { MonitorInProgress } from '../lib/monitorInProgress'
 import { fetchWithController, fetchWithTimeout } from './lib/fetch'
 import { joinUrls } from './lib/pathJoin'
+import { defaultCheckHandleRead, defaultCheckHandleWrite } from './lib/lib'
 
 /** Accessor handle for accessing files in HTTP- */
 export class HTTPProxyAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata> {
@@ -58,27 +59,13 @@ export class HTTPProxyAccessorHandle<Metadata> extends GenericAccessorHandle<Met
 		return !accessor.networkId || worker.agentAPI.location.localNetworkIds.includes(accessor.networkId)
 	}
 	checkHandleRead(): AccessorHandlerCheckHandleReadResult {
-		if (!this.accessor.allowRead) {
-			return {
-				success: false,
-				reason: {
-					user: `Not allowed to read`,
-					tech: `Not allowed to read`,
-				},
-			}
-		}
+		const defaultResult = defaultCheckHandleRead(this.accessor)
+		if (defaultResult) return defaultResult
 		return this.checkAccessor()
 	}
 	checkHandleWrite(): AccessorHandlerCheckHandleWriteResult {
-		if (!this.accessor.allowWrite) {
-			return {
-				success: false,
-				reason: {
-					user: `Not allowed to write`,
-					tech: `Not allowed to write`,
-				},
-			}
-		}
+		const defaultResult = defaultCheckHandleWrite(this.accessor)
+		if (defaultResult) return defaultResult
 		return this.checkAccessor()
 	}
 	async checkPackageReadAccess(): Promise<AccessorHandlerCheckPackageReadAccessResult> {

--- a/shared/packages/worker/src/worker/accessorHandlers/lib/lib.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/lib/lib.ts
@@ -1,0 +1,31 @@
+import { AccessorOnPackage } from '@sofie-package-manager/api'
+import { AccessorHandlerCheckHandleReadResult, AccessorHandlerCheckHandleWriteResult } from '../genericHandle'
+
+export function defaultCheckHandleRead(
+	accessor: AccessorOnPackage.Any
+): AccessorHandlerCheckHandleReadResult | undefined {
+	if (!accessor.allowRead) {
+		return {
+			success: false,
+			reason: {
+				user: `Not allowed to read`,
+				tech: `Not allowed to read  (check PackageContainer settings)`,
+			},
+		}
+	}
+	return undefined
+}
+export function defaultCheckHandleWrite(
+	accessor: AccessorOnPackage.Any
+): AccessorHandlerCheckHandleWriteResult | undefined {
+	if (!accessor.allowWrite) {
+		return {
+			success: false,
+			reason: {
+				user: `Not allowed to write`,
+				tech: `Not allowed to write (check PackageContainer settings)`,
+			},
+		}
+	}
+	return undefined
+}

--- a/shared/packages/worker/src/worker/accessorHandlers/localFolder.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/localFolder.ts
@@ -25,6 +25,7 @@ import { GenericWorker } from '../worker'
 import { GenericFileAccessorHandle, LocalFolderAccessorHandleType } from './lib/FileHandler'
 import { MonitorInProgress } from '../lib/monitorInProgress'
 import { compareResourceIds } from '../workers/windowsWorker/lib/lib'
+import { defaultCheckHandleRead, defaultCheckHandleWrite } from './lib/lib'
 
 const fsStat = promisify(fs.stat)
 const fsAccess = promisify(fs.access)
@@ -77,15 +78,13 @@ export class LocalFolderAccessorHandle<Metadata> extends GenericFileAccessorHand
 	}
 
 	checkHandleRead(): AccessorHandlerCheckHandleReadResult {
-		if (!this.accessor.allowRead) {
-			return { success: false, reason: { user: `Not allowed to read`, tech: `Not allowed to read` } }
-		}
+		const defaultResult = defaultCheckHandleRead(this.accessor)
+		if (defaultResult) return defaultResult
 		return this.checkAccessor()
 	}
 	checkHandleWrite(): AccessorHandlerCheckHandleWriteResult {
-		if (!this.accessor.allowWrite) {
-			return { success: false, reason: { user: `Not allowed to write`, tech: `Not allowed to write` } }
-		}
+		const defaultResult = defaultCheckHandleWrite(this.accessor)
+		if (defaultResult) return defaultResult
 		return this.checkAccessor()
 	}
 	private checkAccessor(): AccessorHandlerCheckHandleWriteResult {

--- a/shared/packages/worker/src/worker/accessorHandlers/localFolder.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/localFolder.ts
@@ -133,16 +133,19 @@ export class LocalFolderAccessorHandle<Metadata> extends GenericFileAccessorHand
 			if (err && (err as any).code === 'EBUSY') {
 				return {
 					success: false,
+					packageExists: true,
 					reason: { user: `Not able to read file (file is busy)`, tech: `${stringifyError(err, true)}` },
 				}
 			} else if (err && (err as any).code === 'ENOENT') {
 				return {
 					success: false,
+					packageExists: false,
 					reason: { user: `File does not exist`, tech: `${stringifyError(err, true)}` },
 				}
 			} else {
 				return {
 					success: false,
+					packageExists: false,
 					reason: { user: `Not able to read file`, tech: `${stringifyError(err, true)}` },
 				}
 			}

--- a/shared/packages/worker/src/worker/accessorHandlers/quantel.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/quantel.ts
@@ -24,6 +24,7 @@ import {
 import { GenericWorker } from '../worker'
 import { ClipData, ClipDataSummary, ServerInfo, ZoneInfo } from 'tv-automation-quantel-gateway-client/dist/quantelTypes'
 import { joinUrls } from './lib/pathJoin'
+import { defaultCheckHandleRead, defaultCheckHandleWrite } from './lib/lib'
 
 /** The minimum amount of frames where a clip is minimumly playable */
 const RESERVED_CLIP_MINIMUM_FRAMES = 10
@@ -67,15 +68,13 @@ export class QuantelAccessorHandle<Metadata> extends GenericAccessorHandle<Metad
 		return !accessor.networkId || worker.agentAPI.location.localNetworkIds.includes(accessor.networkId)
 	}
 	checkHandleRead(): AccessorHandlerCheckHandleReadResult {
-		if (!this.accessor.allowRead) {
-			return { success: false, reason: { user: `Not allowed to read`, tech: `Not allowed to read` } }
-		}
+		const defaultResult = defaultCheckHandleRead(this.accessor)
+		if (defaultResult) return defaultResult
 		return this.checkAccessor()
 	}
 	checkHandleWrite(): AccessorHandlerCheckHandleWriteResult {
-		if (!this.accessor.allowWrite) {
-			return { success: false, reason: { user: `Not allowed to write`, tech: `Not allowed to write` } }
-		}
+		const defaultResult = defaultCheckHandleWrite(this.accessor)
+		if (defaultResult) return defaultResult
 		if (!this.accessor.serverId) {
 			return {
 				success: false,

--- a/shared/packages/worker/src/worker/accessorHandlers/quantel.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/quantel.ts
@@ -5,8 +5,13 @@ import {
 	PackageReadInfoBaseType,
 	PackageReadInfoQuantelClip,
 	PutPackageHandler,
-	AccessorHandlerResult,
 	SetupPackageContainerMonitorsResult,
+	AccessorHandlerTryPackageReadResult,
+	AccessorHandlerCheckPackageReadAccessResult,
+	AccessorHandlerCheckPackageContainerWriteAccessResult,
+	AccessorHandlerCheckHandleReadResult,
+	AccessorHandlerCheckHandleWriteResult,
+	AccessorHandlerRunCronJobResult,
 } from './genericHandle'
 import {
 	Accessor,
@@ -60,13 +65,13 @@ export class QuantelAccessorHandle<Metadata> extends GenericAccessorHandle<Metad
 		const accessor = accessor0 as AccessorOnPackage.Quantel
 		return !accessor.networkId || worker.agentAPI.location.localNetworkIds.includes(accessor.networkId)
 	}
-	checkHandleRead(): AccessorHandlerResult {
+	checkHandleRead(): AccessorHandlerCheckHandleReadResult {
 		if (!this.accessor.allowRead) {
 			return { success: false, reason: { user: `Not allowed to read`, tech: `Not allowed to read` } }
 		}
 		return this.checkAccessor()
 	}
-	checkHandleWrite(): AccessorHandlerResult {
+	checkHandleWrite(): AccessorHandlerCheckHandleWriteResult {
 		if (!this.accessor.allowWrite) {
 			return { success: false, reason: { user: `Not allowed to write`, tech: `Not allowed to write` } }
 		}
@@ -81,7 +86,7 @@ export class QuantelAccessorHandle<Metadata> extends GenericAccessorHandle<Metad
 		}
 		return this.checkAccessor()
 	}
-	private checkAccessor(): AccessorHandlerResult {
+	private checkAccessor(): AccessorHandlerCheckHandleReadResult {
 		if (this.accessor.type !== Accessor.AccessType.QUANTEL) {
 			return {
 				success: false,
@@ -117,7 +122,7 @@ export class QuantelAccessorHandle<Metadata> extends GenericAccessorHandle<Metad
 
 		return { success: true }
 	}
-	async checkPackageReadAccess(): Promise<AccessorHandlerResult> {
+	async checkPackageReadAccess(): Promise<AccessorHandlerCheckPackageReadAccessResult> {
 		const quantel = await this.getQuantelGateway()
 
 		// Search for a clip that match:
@@ -137,7 +142,7 @@ export class QuantelAccessorHandle<Metadata> extends GenericAccessorHandle<Metad
 			}
 		}
 	}
-	async tryPackageRead(): Promise<AccessorHandlerResult> {
+	async tryPackageRead(): Promise<AccessorHandlerTryPackageReadResult> {
 		const quantel = await this.getQuantelGateway()
 
 		const clipSummary = await this.searchForLatestClip(quantel)
@@ -171,7 +176,7 @@ export class QuantelAccessorHandle<Metadata> extends GenericAccessorHandle<Metad
 
 		return { success: true }
 	}
-	async checkPackageContainerWriteAccess(): Promise<AccessorHandlerResult> {
+	async checkPackageContainerWriteAccess(): Promise<AccessorHandlerCheckPackageContainerWriteAccessResult> {
 		const quantel = await this.getQuantelGateway()
 
 		const server = await quantel.getServer()
@@ -332,7 +337,7 @@ export class QuantelAccessorHandle<Metadata> extends GenericAccessorHandle<Metad
 	async removeMetadata(): Promise<void> {
 		// Not supported, do nothing
 	}
-	async runCronJob(): Promise<AccessorHandlerResult> {
+	async runCronJob(): Promise<AccessorHandlerRunCronJobResult> {
 		return {
 			success: true,
 		} // not applicable

--- a/shared/packages/worker/src/worker/accessorHandlers/quantel.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/quantel.ts
@@ -162,7 +162,7 @@ export class QuantelAccessorHandle<Metadata> extends GenericAccessorHandle<Metad
 				success: false,
 				packageExists: true,
 				reason: {
-					user: `Clip has no frames`,
+					user: `Reserved clip`,
 					tech: `Clip "${clipSummary.ClipGUID}" has no frames`,
 				},
 			}
@@ -177,7 +177,7 @@ export class QuantelAccessorHandle<Metadata> extends GenericAccessorHandle<Metad
 				success: false,
 				packageExists: true,
 				reason: {
-					user: `Clip not yet published`,
+					user: `Reserved clip`,
 					tech: `Clip "${clipSummary.ClipGUID}" hasn't received enough frames (${clipSummary.Frames})`,
 				},
 			}

--- a/shared/packages/worker/src/worker/accessorHandlers/quantel.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/quantel.ts
@@ -175,7 +175,7 @@ export class QuantelAccessorHandle<Metadata> extends GenericAccessorHandle<Metad
 			// Check that it is meaningfully playable
 			return {
 				success: false,
-				packageExists: false,
+				packageExists: true,
 				reason: {
 					user: `Clip not yet published`,
 					tech: `Clip "${clipSummary.ClipGUID}" hasn't received enough frames (${clipSummary.Frames})`,

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/jsonDataCopy.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/jsonDataCopy.ts
@@ -53,7 +53,8 @@ export const JsonDataCopy: ExpectationWindowsHandler = {
 		// Also check if we actually can read from the package,
 		// this might help in some cases if the file is currently transferring
 		const tryReading = await lookupSource.handle.tryPackageRead()
-		if (!tryReading.success) return { ready: false, reason: tryReading.reason }
+		if (!tryReading.success)
+			return { ready: false, sourceExists: tryReading.packageExists, reason: tryReading.reason }
 
 		return {
 			ready: true,

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/jsonDataCopy.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/jsonDataCopy.ts
@@ -57,7 +57,6 @@ export const JsonDataCopy: ExpectationWindowsHandler = {
 
 		return {
 			ready: true,
-			sourceExists: true,
 		}
 	},
 	isExpectationFullfilled: async (

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/lib/file.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/lib/file.ts
@@ -82,11 +82,6 @@ export async function isFileReadyToStartWorkingOn(
 
 	return {
 		ready: true,
-		sourceExists: true,
-		// reason: {
-		// 	user: 'Ready to start copying',
-		// 	tech: `${lookupSource.reason.user}, ${lookupTarget.reason.tech}`,
-		// },
 	}
 }
 export async function isFileFulfilled(

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/lib/file.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/lib/file.ts
@@ -78,7 +78,7 @@ export async function isFileReadyToStartWorkingOn(
 	// Also check if we actually can read from the package,
 	// this might help in some cases if the file is currently transferring
 	const tryReading = await lookupSource.handle.tryPackageRead()
-	if (!tryReading.success) return { ready: false, reason: tryReading.reason }
+	if (!tryReading.success) return { ready: false, sourceExists: tryReading.packageExists, reason: tryReading.reason }
 
 	return {
 		ready: true,

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/mediaFilePreview.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/mediaFilePreview.ts
@@ -74,8 +74,6 @@ export const MediaFilePreview: ExpectationWindowsHandler = {
 
 		return {
 			ready: true,
-			sourceExists: true,
-			// reason: `${lookupSource.reason.user}, ${lookupTarget.reason.tech}`,
 		}
 	},
 	isExpectationFullfilled: async (

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/mediaFilePreview.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/mediaFilePreview.ts
@@ -70,7 +70,8 @@ export const MediaFilePreview: ExpectationWindowsHandler = {
 		if (!lookupTarget.ready) return { ready: lookupTarget.ready, reason: lookupTarget.reason }
 
 		const tryReading = await lookupSource.handle.tryPackageRead()
-		if (!tryReading.success) return { ready: false, reason: tryReading.reason }
+		if (!tryReading.success)
+			return { ready: false, sourceExists: tryReading.packageExists, reason: tryReading.reason }
 
 		return {
 			ready: true,

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/mediaFileThumbnail.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/mediaFileThumbnail.ts
@@ -70,7 +70,8 @@ export const MediaFileThumbnail: ExpectationWindowsHandler = {
 		if (!lookupTarget.ready) return { ready: lookupTarget.ready, reason: lookupTarget.reason }
 
 		const tryReading = await lookupSource.handle.tryPackageRead()
-		if (!tryReading.success) return { ready: false, reason: tryReading.reason }
+		if (!tryReading.success)
+			return { ready: false, sourceExists: tryReading.packageExists, reason: tryReading.reason }
 
 		return {
 			ready: true,

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/mediaFileThumbnail.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/mediaFileThumbnail.ts
@@ -74,8 +74,6 @@ export const MediaFileThumbnail: ExpectationWindowsHandler = {
 
 		return {
 			ready: true,
-			sourceExists: true,
-			// reason: `${lookupSource.reason.user}, ${lookupTarget.reason.tech}`,
 		}
 	},
 	isExpectationFullfilled: async (

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/packageDeepScan.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/packageDeepScan.ts
@@ -69,7 +69,8 @@ export const PackageDeepScan: ExpectationWindowsHandler = {
 		if (!lookupTarget.ready) return { ready: lookupTarget.ready, reason: lookupTarget.reason }
 
 		const tryReading = await lookupSource.handle.tryPackageRead()
-		if (!tryReading.success) return { ready: false, reason: tryReading.reason }
+		if (!tryReading.success)
+			return { ready: false, sourceExists: tryReading.packageExists, reason: tryReading.reason }
 
 		return {
 			ready: true,

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/packageDeepScan.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/packageDeepScan.ts
@@ -73,8 +73,6 @@ export const PackageDeepScan: ExpectationWindowsHandler = {
 
 		return {
 			ready: true,
-			sourceExists: true,
-			// reason: `${lookupSource.reason.user}, ${lookupTarget.reason.tech}`,
 		}
 	},
 	isExpectationFullfilled: async (

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/packageScan.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/packageScan.ts
@@ -67,7 +67,8 @@ export const PackageScan: ExpectationWindowsHandler = {
 		if (!lookupTarget.ready) return { ready: lookupTarget.ready, reason: lookupTarget.reason }
 
 		const tryReading = await lookupSource.handle.tryPackageRead()
-		if (!tryReading.success) return { ready: false, reason: tryReading.reason }
+		if (!tryReading.success)
+			return { ready: false, sourceExists: tryReading.packageExists, reason: tryReading.reason }
 
 		return {
 			ready: true,

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/packageScan.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/packageScan.ts
@@ -71,7 +71,6 @@ export const PackageScan: ExpectationWindowsHandler = {
 
 		return {
 			ready: true,
-			sourceExists: true,
 		}
 	},
 	isExpectationFullfilled: async (

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/quantelClipCopy.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/quantelClipCopy.ts
@@ -60,7 +60,8 @@ export const QuantelClipCopy: ExpectationWindowsHandler = {
 
 		// Also check if we actually can read from the package:
 		const tryReading = await lookupSource.handle.tryPackageRead()
-		if (!tryReading.success) return { ready: false, reason: tryReading.reason }
+		if (!tryReading.success)
+			return { ready: false, sourceExists: tryReading.packageExists, reason: tryReading.reason }
 
 		return {
 			ready: true,

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/quantelClipCopy.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/quantelClipCopy.ts
@@ -64,8 +64,6 @@ export const QuantelClipCopy: ExpectationWindowsHandler = {
 
 		return {
 			ready: true,
-			sourceExists: true,
-			// reason: `${lookupSource.reason.user}, ${lookupTarget.reason.tech}`,
 		}
 	},
 	isExpectationFullfilled: async (

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/quantelClipPreview.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/quantelClipPreview.ts
@@ -66,8 +66,9 @@ export const QuantelClipPreview: ExpectationWindowsHandler = {
 		const lookupTarget = await lookupPreviewTargets(worker, exp)
 		if (!lookupTarget.ready) return { ready: lookupTarget.ready, reason: lookupTarget.reason }
 
-		const tryResult = await lookupSource.handle.tryPackageRead()
-		if (!tryResult.success) return { ready: false, reason: tryResult.reason }
+		const tryReading = await lookupSource.handle.tryPackageRead()
+		if (!tryReading.success)
+			return { ready: false, sourceExists: tryReading.packageExists, reason: tryReading.reason }
 
 		// This is a bit special, as we use the Quantel HTTP-transformer to get a HLS-stream of the video:
 		if (!isQuantelClipAccessorHandle(lookupSource.handle)) throw new Error(`Source AccessHandler type is wrong`)
@@ -81,7 +82,8 @@ export const QuantelClipPreview: ExpectationWindowsHandler = {
 		const sourceHTTPHandle = getSourceHTTPHandle(worker, lookupSource.handle, httpStreamURL)
 
 		const tryReadingHTTP = await sourceHTTPHandle.tryPackageRead()
-		if (!tryReadingHTTP.success) return { ready: false, reason: tryReadingHTTP.reason }
+		if (!tryReadingHTTP.success)
+			return { ready: false, sourceExists: tryReadingHTTP.packageExists, reason: tryReadingHTTP.reason }
 
 		return {
 			ready: true,

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/quantelClipPreview.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/quantelClipPreview.ts
@@ -85,7 +85,6 @@ export const QuantelClipPreview: ExpectationWindowsHandler = {
 
 		return {
 			ready: true,
-			sourceExists: true,
 		}
 	},
 	isExpectationFullfilled: async (

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/quantelClipThumbnail.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/quantelClipThumbnail.ts
@@ -82,7 +82,6 @@ export const QuantelThumbnail: ExpectationWindowsHandler = {
 
 		return {
 			ready: true,
-			sourceExists: true,
 		}
 	},
 	isExpectationFullfilled: async (

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/quantelClipThumbnail.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/quantelClipThumbnail.ts
@@ -65,8 +65,9 @@ export const QuantelThumbnail: ExpectationWindowsHandler = {
 		const lookupTarget = await lookupThumbnailTargets(worker, exp)
 		if (!lookupTarget.ready) return { ready: lookupTarget.ready, reason: lookupTarget.reason }
 
-		const tryResult = await lookupSource.handle.tryPackageRead()
-		if (!tryResult.success) return { ready: false, reason: tryResult.reason }
+		const tryReading = await lookupSource.handle.tryPackageRead()
+		if (!tryReading.success)
+			return { ready: false, sourceExists: tryReading.packageExists, reason: tryReading.reason }
 
 		// This is a bit special, as we use the Quantel HTTP-transformer to extract the thumbnail:
 		const thumbnailURL = await getThumbnailURL(exp, lookupSource)
@@ -78,7 +79,8 @@ export const QuantelThumbnail: ExpectationWindowsHandler = {
 		const sourceHTTPHandle = getSourceHTTPHandle(worker, lookupSource.handle, thumbnailURL)
 
 		const tryReadingHTTP = await sourceHTTPHandle.tryPackageRead()
-		if (!tryReadingHTTP.success) return { ready: false, reason: tryReadingHTTP.reason }
+		if (!tryReadingHTTP.success)
+			return { ready: false, sourceExists: tryReadingHTTP.packageExists, reason: tryReadingHTTP.reason }
 
 		return {
 			ready: true,

--- a/shared/packages/worker/src/worker/workers/windowsWorker/lib/lib.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/lib/lib.ts
@@ -8,12 +8,12 @@ import {
 	ReturnTypeGetCostFortExpectation,
 } from '@sofie-package-manager/api'
 import { prioritizeAccessors } from '../../../lib/lib'
-import { AccessorHandlerResult } from '../../../accessorHandlers/genericHandle'
+import { AccessorHandlerResultGeneric } from '../../../accessorHandlers/genericHandle'
 
 export function compareActualExpectVersions(
 	actualVersion: Expectation.Version.Any,
 	expectVersion: Expectation.Version.ExpectAny
-): AccessorHandlerResult {
+): AccessorHandlerResultGeneric {
 	const expectProperties = makeUniversalVersion(expectVersion)
 	const actualProperties = makeUniversalVersion(actualVersion)
 
@@ -37,7 +37,7 @@ export function compareActualExpectVersions(
 export function compareUniversalVersions(
 	sourceVersion: UniversalVersion,
 	targetVersion: UniversalVersion
-): AccessorHandlerResult {
+): AccessorHandlerResultGeneric {
 	for (const key of Object.keys(sourceVersion)) {
 		const source = sourceVersion[key]
 		const target = targetVersion[key]

--- a/tests/internal-tests/src/__mocks__/tv-automation-quantel-gateway-client.ts
+++ b/tests/internal-tests/src/__mocks__/tv-automation-quantel-gateway-client.ts
@@ -57,6 +57,14 @@ export function resetMock(): void {
 							Completed: '2020-01-01',
 							Frames: '1337',
 						},
+						{
+							ClipID: 11,
+							ClipGUID: 'abc123-reserved-clip',
+							Title: 'i-am-a-reserved-clip',
+							CloneId: null,
+							Completed: '2020-01-01',
+							Frames: '5',
+						},
 					],
 				},
 			],
@@ -125,6 +133,23 @@ export function searchClip(searchQuery: (clip: MockClip) => boolean): SearchResu
 	return foundClips
 }
 client.searchClip = searchClip
+
+export function updateClip(updateFunction: (clip: MockClip) => MockClip | null | undefined): void {
+	for (const server of mock.servers) {
+		for (const pool of server.pools) {
+			const updatedClips: MockClip[] = []
+			for (const clip of pool.clips) {
+				const updatedClip = updateFunction(clip)
+
+				if (updatedClip === null) continue
+				else if (updatedClip === undefined) updatedClips.push(clip)
+				else updatedClips.push(updatedClip)
+			}
+			pool.clips = updatedClips
+		}
+	}
+}
+client.updateClip = updateClip
 
 export const QuantelGatewayInstances: QuantelGateway[] = []
 client.QuantelGatewayInstances = QuantelGatewayInstances


### PR DESCRIPTION
This PR includes some refactoring, but mainly it adds the `packageExists` property to the result of `tryPackageRead()` method, in order to return better sourceExists from `isFileReadyToStartWorkingOn()`.

In practice, this causes "reserved quantel clips" to get the status NOT_READY instead of NOT_FOUND, which is slightly more accurate.