### PR TITLE
fix: bug in joinUrls

### DIFF
--- a/shared/packages/worker/src/worker/accessorHandlers/lib/__tests__/pathJoin.spec.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/lib/__tests__/pathJoin.spec.ts
@@ -1,0 +1,11 @@
+import { joinUrls } from '../pathJoin'
+test('joinUrls', () => {
+	expect(joinUrls('a', 'b')).toBe('a/b')
+	expect(joinUrls('a/', 'b')).toBe('a/b')
+	expect(joinUrls('a/', '/b')).toBe('a/b')
+	expect(joinUrls('a/', '/b/')).toBe('a/b/')
+	expect(joinUrls('//a/b/', 'c')).toBe('/a/b/c')
+	expect(joinUrls('a/', '//b/')).toBe('a/b/')
+
+	expect(joinUrls('a/b//c/', '/d/e//f/')).toBe('a/b/c/d/e/f/')
+})

--- a/shared/packages/worker/src/worker/accessorHandlers/lib/pathJoin.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/lib/pathJoin.ts
@@ -7,11 +7,6 @@ export function removeBasePath(basePath: string, addPath: string): string {
 function escapeRegExp(text: string): string {
 	return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
 }
-export function joinUrls(url0: string, url1: string): string {
-	return [
-		url0.replace(/\/$/, ''), // trim trailing slash
-		url1.replace(/^\//, ''), // trim leading slash
-	]
-		.join('/')
-		.replace(/[^:]\/\//g, '/') // replace double slashes
+export function joinUrls(...urls: string[]): string {
+	return urls.join('/').replace(/\/{2,}/g, '/') // Remove double slashes
 }


### PR DESCRIPTION
This PR fixes a bug and adds unit tests for the `joinUrls` function.

The bug appeared when trying to join the paths `joinUrls("asdf/package", "//nas/folder/path")`