### PR TITLE
fix: handle # in filenames and urls (%23, when URI encoded)

### DIFF
--- a/apps/http-server/packages/generic/src/storage/fileStorage.ts
+++ b/apps/http-server/packages/generic/src/storage/fileStorage.ts
@@ -8,6 +8,7 @@ import { CTX, CTXPost } from '../lib'
 import { HTTPServerConfig, LoggerInstance } from '@sofie-package-manager/api'
 import { BadResponse, Storage } from './storage'
 import { Readable } from 'stream'
+import { makeFileNameUrlSafe } from '@sofie-package-manager/api'
 
 // Note: Explicit types here, due to that for some strange reason, promisify wont pass through the correct typings.
 const fsStat = promisify(fs.stat)
@@ -134,7 +135,7 @@ export class FileStorage extends Storage {
 		return true
 	}
 	async getPackage(paramPath: string, ctx: CTX): Promise<true | BadResponse> {
-		const uriEncodedParamPath = encodeURIComponent(paramPath)
+		const uriEncodedParamPath = makeFileNameUrlSafe(paramPath)
 		const fileInfo = await this.getFileInfo(uriEncodedParamPath)
 
 		if (!fileInfo.found) {

--- a/apps/http-server/packages/generic/src/storage/fileStorage.ts
+++ b/apps/http-server/packages/generic/src/storage/fileStorage.ts
@@ -134,7 +134,8 @@ export class FileStorage extends Storage {
 		return true
 	}
 	async getPackage(paramPath: string, ctx: CTX): Promise<true | BadResponse> {
-		const fileInfo = await this.getFileInfo(paramPath)
+		const uriEncodedParamPath = encodeURIComponent(paramPath)
+		const fileInfo = await this.getFileInfo(uriEncodedParamPath)
 
 		if (!fileInfo.found) {
 			return { code: 404, reason: 'Package not found' }

--- a/apps/http-server/packages/generic/src/storage/fileStorage.ts
+++ b/apps/http-server/packages/generic/src/storage/fileStorage.ts
@@ -8,7 +8,6 @@ import { CTX, CTXPost } from '../lib'
 import { HTTPServerConfig, LoggerInstance } from '@sofie-package-manager/api'
 import { BadResponse, Storage } from './storage'
 import { Readable } from 'stream'
-import { makeFileNameUrlSafe } from '@sofie-package-manager/api'
 
 // Note: Explicit types here, due to that for some strange reason, promisify wont pass through the correct typings.
 const fsStat = promisify(fs.stat)
@@ -135,8 +134,7 @@ export class FileStorage extends Storage {
 		return true
 	}
 	async getPackage(paramPath: string, ctx: CTX): Promise<true | BadResponse> {
-		const uriEncodedParamPath = makeFileNameUrlSafe(paramPath)
-		const fileInfo = await this.getFileInfo(uriEncodedParamPath)
+		const fileInfo = await this.getFileInfo(paramPath)
 
 		if (!fileInfo.found) {
 			return { code: 404, reason: 'Package not found' }

--- a/shared/packages/api/src/lib.ts
+++ b/shared/packages/api/src/lib.ts
@@ -326,3 +326,6 @@ export function ensureValidValue<T>(value: T, check: (value: any) => boolean, de
 	if (check(value)) return value
 	return defaultValue
 }
+export function makeFileNameUrlSafe(fileName: string): string {
+	return encodeURIComponent(fileName)
+}

--- a/shared/packages/worker/src/worker/accessorHandlers/http.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/http.ts
@@ -184,7 +184,7 @@ export class HTTPAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 		return { success: true, monitors: resultingMonitors }
 	}
 	get fullUrl(): string {
-		return joinUrls(this.baseUrl, this.path)
+		return joinUrls(this.baseUrl, encodeURIComponent(this.path))
 	}
 
 	private checkAccessor(): AccessorHandlerCheckHandleWriteResult {
@@ -314,7 +314,7 @@ export class HTTPAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 			// Check if it is time to remove the package:
 			if (entry.removeTime < Date.now()) {
 				// it is time to remove the package:
-				const fullUrl: string = joinUrls(this.baseUrl, entry.filePath)
+				const fullUrl: string = joinUrls(this.baseUrl, encodeURIComponent(entry.filePath))
 
 				await this.deletePackageIfExists(this.getMetadataPath(fullUrl))
 				await this.deletePackageIfExists(fullUrl)

--- a/shared/packages/worker/src/worker/accessorHandlers/http.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/http.ts
@@ -25,6 +25,7 @@ import FormData from 'form-data'
 import { MonitorInProgress } from '../lib/monitorInProgress'
 import { joinUrls } from './lib/pathJoin'
 import { defaultCheckHandleRead, defaultCheckHandleWrite } from './lib/lib'
+import { makeFileNameUrlSafe } from '@sofie-package-manager/api'
 
 /** Accessor handle for accessing files in a local folder */
 export class HTTPAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata> {
@@ -184,7 +185,7 @@ export class HTTPAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 		return { success: true, monitors: resultingMonitors }
 	}
 	get fullUrl(): string {
-		return joinUrls(this.baseUrl, encodeURIComponent(this.path))
+		return joinUrls(this.baseUrl, makeFileNameUrlSafe(this.path))
 	}
 
 	private checkAccessor(): AccessorHandlerCheckHandleWriteResult {
@@ -314,7 +315,7 @@ export class HTTPAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata
 			// Check if it is time to remove the package:
 			if (entry.removeTime < Date.now()) {
 				// it is time to remove the package:
-				const fullUrl: string = joinUrls(this.baseUrl, encodeURIComponent(entry.filePath))
+				const fullUrl: string = joinUrls(this.baseUrl, makeFileNameUrlSafe(entry.filePath))
 
 				await this.deletePackageIfExists(this.getMetadataPath(fullUrl))
 				await this.deletePackageIfExists(fullUrl)

--- a/shared/packages/worker/src/worker/accessorHandlers/httpProxy.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/httpProxy.ts
@@ -210,7 +210,7 @@ export class HTTPProxyAccessorHandle<Metadata> extends GenericAccessorHandle<Met
 		return { success: true, monitors: resultingMonitors }
 	}
 	get fullUrl(): string {
-		return joinUrls(this.baseUrl, this.filePath)
+		return joinUrls(this.baseUrl, encodeURIComponent(this.filePath))
 	}
 
 	private checkAccessor(): AccessorHandlerCheckHandleWriteResult {
@@ -340,7 +340,7 @@ export class HTTPProxyAccessorHandle<Metadata> extends GenericAccessorHandle<Met
 			// Check if it is time to remove the package:
 			if (entry.removeTime < Date.now()) {
 				// it is time to remove the package:
-				const fullUrl: string = joinUrls(this.baseUrl, entry.filePath)
+				const fullUrl: string = joinUrls(this.baseUrl, encodeURIComponent(entry.filePath))
 
 				await this.deletePackageIfExists(this.getMetadataPath(fullUrl))
 				await this.deletePackageIfExists(fullUrl)

--- a/shared/packages/worker/src/worker/accessorHandlers/httpProxy.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/httpProxy.ts
@@ -25,6 +25,7 @@ import { MonitorInProgress } from '../lib/monitorInProgress'
 import { fetchWithController, fetchWithTimeout } from './lib/fetch'
 import { joinUrls } from './lib/pathJoin'
 import { defaultCheckHandleRead, defaultCheckHandleWrite } from './lib/lib'
+import { makeFileNameUrlSafe } from '@sofie-package-manager/api'
 
 /** Accessor handle for accessing files in HTTP- */
 export class HTTPProxyAccessorHandle<Metadata> extends GenericAccessorHandle<Metadata> {
@@ -210,7 +211,7 @@ export class HTTPProxyAccessorHandle<Metadata> extends GenericAccessorHandle<Met
 		return { success: true, monitors: resultingMonitors }
 	}
 	get fullUrl(): string {
-		return joinUrls(this.baseUrl, encodeURIComponent(this.filePath))
+		return joinUrls(this.baseUrl, makeFileNameUrlSafe(this.filePath))
 	}
 
 	private checkAccessor(): AccessorHandlerCheckHandleWriteResult {
@@ -340,7 +341,7 @@ export class HTTPProxyAccessorHandle<Metadata> extends GenericAccessorHandle<Met
 			// Check if it is time to remove the package:
 			if (entry.removeTime < Date.now()) {
 				// it is time to remove the package:
-				const fullUrl: string = joinUrls(this.baseUrl, encodeURIComponent(entry.filePath))
+				const fullUrl: string = joinUrls(this.baseUrl, makeFileNameUrlSafe(entry.filePath))
 
 				await this.deletePackageIfExists(this.getMetadataPath(fullUrl))
 				await this.deletePackageIfExists(fullUrl)

--- a/shared/packages/worker/src/worker/accessorHandlers/lib/fetch.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/lib/fetch.ts
@@ -71,8 +71,6 @@ export function fetchWithController(
 ): { response: Promise<Response>; controller: AbortController } {
 	const controller = new AbortController()
 
-	// encode, to avoid issues with special characters such as åäöØÅÖÆÅ
-	url = encodeURI(url)
 	return {
 		response: new Promise((resolve, reject) => {
 			const refreshTimeout = () => {


### PR DESCRIPTION
This PR is being opened on behalf of TV 2 Norway.

TV 2 Norway has some files with `#` characters in them. Because of the semantic meaning of `#` in URLs (specifically: the fact that anything after a `#` is never sent to the server in an HTTP request), we have to ensure that we treat filenames with this character in it appropriately.

I've tested this with a few different filenames, both containing `#` and not, but this should definitely get tested against a more comprehensive NRK suite before being merged.