### PR TITLE
fix: Thumbnails & Previews linger for packages that are long gone (SOFIE-2293)

### DIFF
--- a/apps/package-manager/packages/generic/src/generateExpectations/nrk/expectations-lib.ts
+++ b/apps/package-manager/packages/generic/src/generateExpectations/nrk/expectations-lib.ts
@@ -388,7 +388,8 @@ export function generateMediaFileThumbnail(
 			...expectation.workOptions,
 			allowWaitForCPU: true,
 			usesCPUCount: 1,
-			removeDelay: 0, // The removal of the scan itself shouldn't be delayed
+			removeDelay: 0, // The removal of the thumnail shouldn't be delayed
+			removePackageOnUnFulfill: true,
 		},
 		dependsOnFullfilled: [expectation.id],
 		triggerByFullfilledIds: [expectation.id],
@@ -440,7 +441,8 @@ export function generateMediaFilePreview(
 			...expectation.workOptions,
 			allowWaitForCPU: true,
 			usesCPUCount: 1,
-			removeDelay: 0, // The removal of the scan itself shouldn't be delayed
+			removeDelay: 0, // The removal of the preview shouldn't be delayed
+			removePackageOnUnFulfill: true,
 		},
 		dependsOnFullfilled: [expectation.id],
 		triggerByFullfilledIds: [expectation.id],
@@ -493,7 +495,8 @@ export function generateQuantelClipThumbnail(
 			...expectation.workOptions,
 			allowWaitForCPU: true,
 			usesCPUCount: 1,
-			removeDelay: 0, // The removal of the scan itself shouldn't be delayed
+			removeDelay: 0, // The removal of the thumbnail shouldn't be delayed
+			removePackageOnUnFulfill: true,
 		},
 		dependsOnFullfilled: [expectation.id],
 		triggerByFullfilledIds: [expectation.id],
@@ -547,7 +550,8 @@ export function generateQuantelClipPreview(
 			...expectation.workOptions,
 			allowWaitForCPU: true,
 			usesCPUCount: 1,
-			removeDelay: 0, // The removal of the scan itself shouldn't be delayed
+			removeDelay: 0, // The removal of the preview shouldn't be delayed
+			removePackageOnUnFulfill: true,
 		},
 		dependsOnFullfilled: [expectation.id],
 		triggerByFullfilledIds: [expectation.id],

--- a/shared/packages/api/src/expectationApi.ts
+++ b/shared/packages/api/src/expectationApi.ts
@@ -85,7 +85,8 @@ export namespace Expectation {
 		/** Contains info that can be used during work on an expectation. Changes in this does NOT cause an invalidation of the expectation. */
 		workOptions: WorkOptions.Base
 		/** Reference to another expectation.
-		 * Won't start until ALL other expectations are fullfilled
+		 * Won't start until ALL other expectations are fullfilled.
+		 * If any of the other expectations are not fulfilled, this wont be fulfilled either.
 		 */
 		dependsOnFullfilled?: string[]
 		/** Reference to another expectation.

--- a/shared/packages/api/src/expectationApi.ts
+++ b/shared/packages/api/src/expectationApi.ts
@@ -369,6 +369,8 @@ export namespace Expectation {
 			allowWaitForCPU?: boolean
 			/** If set, specifies how many CPU cores the work is using. */
 			usesCPUCount?: number
+			/** If set, removes the target package if the expectation becomes unfulfilled. */
+			removePackageOnUnFulfill?: boolean
 		}
 		export interface RemoveDelay {
 			/** When removing, wait a duration of time before actually removing it (milliseconds). If not set, package is removed right away. */

--- a/shared/packages/expectationManager/src/evaluationRunner/evaluateExpectationStates/fulfilled.ts
+++ b/shared/packages/expectationManager/src/evaluationRunner/evaluateExpectationStates/fulfilled.ts
@@ -51,6 +51,14 @@ export async function evaluateExpectationStateFulfilled({
 
 				if (notFulfilledReason) {
 					// If is not fulfilled anymore
+
+					if (trackedExp.exp.workOptions.removePackageOnUnFulfill) {
+						const removed = await trackedExp.session.assignedWorker.worker.removeExpectation(trackedExp.exp)
+						if (!removed.removed) {
+							runner.logger.warn(`Unable to remove expectation, reason: ${removed.reason.tech}`)
+						}
+					}
+
 					trackedExp.status.actualVersionHash = undefined
 					trackedExp.status.workProgress = undefined
 					tracker.trackedExpectationAPI.updateTrackedExpectationStatus(trackedExp, {

--- a/shared/packages/expectationManager/src/evaluationRunner/evaluateExpectationStates/fulfilled.ts
+++ b/shared/packages/expectationManager/src/evaluationRunner/evaluateExpectationStates/fulfilled.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line node/no-extraneous-import
 import { ExpectedPackageStatusAPI } from '@sofie-automation/shared-lib/dist/package-manager/package'
-import { stringifyError } from '@sofie-package-manager/api'
+import { Reason, stringifyError } from '@sofie-package-manager/api'
 import { assertState, EvaluateContext } from '../lib'
 
 /**
@@ -24,23 +24,43 @@ export async function evaluateExpectationStateFulfilled({
 		await manager.workerAgents.assignWorkerToSession(trackedExp)
 		if (trackedExp.session.assignedWorker) {
 			try {
-				// Check if it is still fulfilled:
-				const fulfilled = await trackedExp.session.assignedWorker.worker.isExpectationFullfilled(
-					trackedExp.exp,
-					true
-				)
-				if (fulfilled.fulfilled) {
-					// Yes it is still fullfiled
-					// No need to update the tracked state, since it's already fullfilled:
-					// this.updateTrackedExp(trackedExp, WorkStatusState.FULFILLED, fulfilled.reason)
-				} else {
-					// It appears like it's not fullfilled anymore
+				let notFulfilledReason: Reason | null = null
+
+				if (!notFulfilledReason) {
+					const waitingFor = tracker.trackedExpectationAPI.isExpectationWaitingForOther(trackedExp)
+					if (waitingFor) {
+						// Since a dependant is not fulfilled, this one isn't either.
+						notFulfilledReason = {
+							user: `Waiting for "${waitingFor.exp.statusReport.label}"`,
+							tech: `Waiting for "${waitingFor.exp.statusReport.label}"`,
+						}
+					}
+				}
+
+				if (!notFulfilledReason) {
+					// Check if it is still fulfilled:
+					const fulfilled = await trackedExp.session.assignedWorker.worker.isExpectationFullfilled(
+						trackedExp.exp,
+						true
+					)
+					if (!fulfilled.fulfilled) {
+						// It appears like it's not fullfilled anymore
+						notFulfilledReason = fulfilled.reason
+					}
+				}
+
+				if (notFulfilledReason) {
+					// If is not fulfilled anymore
 					trackedExp.status.actualVersionHash = undefined
 					trackedExp.status.workProgress = undefined
 					tracker.trackedExpectationAPI.updateTrackedExpectationStatus(trackedExp, {
 						state: ExpectedPackageStatusAPI.WorkStatusState.NEW,
-						reason: fulfilled.reason,
+						reason: notFulfilledReason,
 					})
+				} else {
+					// Yes it is still fullfiled
+					// No need to update the tracked state, since it's already fullfilled:
+					// this.updateTrackedExp(trackedExp, WorkStatusState.FULFILLED, fulfilled.reason)
 				}
 			} catch (error) {
 				runner.logger.warn(`Error in FULFILLED: ${stringifyError(error)}`)

--- a/tests/internal-tests/src/__mocks__/fs.ts
+++ b/tests/internal-tests/src/__mocks__/fs.ts
@@ -260,6 +260,11 @@ export function __mockSetFile(path: string, size: number, accessOptions?: FileAc
 	)
 }
 fs.__mockSetFile = __mockSetFile
+export function __mockDeleteFile(path: string): void {
+	path = fixPath(path)
+	deleteMock(path)
+}
+fs.__mockDeleteFile = __mockDeleteFile
 export function __mockSetDirectory(path: string, accessOptions?: FileAccess): void {
 	path = fixPath(path)
 	setMock(

--- a/tests/internal-tests/src/__tests__/issues.spec.ts
+++ b/tests/internal-tests/src/__tests__/issues.spec.ts
@@ -16,7 +16,21 @@ jest.mock('tv-automation-quantel-gateway-client')
 
 const fs = fsOrg as any as typeof fsMockType
 
+const fsAccess = promisify(fs.access)
 const fsStat = promisify(fs.stat)
+
+const fsExists = async (filePath: string) => {
+	let exists = false
+	try {
+		await fsAccess(filePath, undefined)
+		// The file exists
+		exists = true
+	} catch (err) {
+		// Ignore
+	}
+
+	return exists
+}
 
 // const fsStat = promisify(fs.stat)
 
@@ -318,7 +332,7 @@ describe('Handle unhappy paths', () => {
 		// To be written
 		expect(1).toEqual(1)
 	})
-	test('When original work step fails, subsequent steps should do so too', async () => {
+	test.only('When original work step fails, subsequent steps should do so too', async () => {
 		// Step 1: Copy from A to B
 		// Step 2: Copy from B to C
 
@@ -373,7 +387,9 @@ describe('Handle unhappy paths', () => {
 					},
 					version: { type: Expectation.Version.Type.FILE_ON_DISK },
 				},
-				workOptions: {},
+				workOptions: {
+					removePackageOnUnFulfill: true,
+				},
 			}),
 		})
 
@@ -420,6 +436,11 @@ describe('Handle unhappy paths', () => {
 			expect(env.expectationStatuses['step1'].statusInfo.status).toMatch(/waiting|new/)
 			expect(env.expectationStatuses['step2'].statusInfo.status).toMatch(/waiting|new/)
 		}, env.WAIT_JOB_TIME)
+
+		// The step1-copied file should remain, since removePackageOnUnFulfill is not set
+		expect(await fsExists('/targets/target0/myFolder/file0Target.mp4')).toBe(true)
+		// The step2-copied file should be removed, since removePackageOnUnFulfill is true
+		expect(await fsExists('/targets/target1/myFolder/file0Target.mp4')).toBe(false)
 
 		// Source file shows up again:
 		fs.__mockSetFile('/sources/source0/file0Source.mp4', 1234)

--- a/tests/internal-tests/src/__tests__/issues.spec.ts
+++ b/tests/internal-tests/src/__tests__/issues.spec.ts
@@ -27,7 +27,7 @@ describe('Handle unhappy paths', () => {
 	let env: TestEnviromnent
 
 	beforeAll(async () => {
-		env = await prepareTestEnviromnent(true) // set to true to enable debug-logging
+		env = await prepareTestEnviromnent(false) // set to true to enable debug-logging
 		// Verify that the fs mock works:
 		expect(fs.lstat).toBeTruthy()
 		expect(fs.__mockReset).toBeTruthy()
@@ -71,12 +71,6 @@ describe('Handle unhappy paths', () => {
 		)
 
 		// Now the file suddenly pops up:
-		console.log('=============================================')
-		console.log('=============================================')
-		console.log('=============================================')
-		console.log('=============================================')
-		console.log('=============================================')
-		console.log('=============================================')
 		fs.__mockSetFile('/sources/source0/file0Source.mp4', 1234)
 
 		// Wait for the job to complete:
@@ -323,6 +317,118 @@ describe('Handle unhappy paths', () => {
 
 		// To be written
 		expect(1).toEqual(1)
+	})
+	test('When original work step fails, subsequent steps should do so too', async () => {
+		// Step 1: Copy from A to B
+		// Step 2: Copy from B to C
+
+		fs.__mockSetFile('/sources/source0/file0Source.mp4', 1234)
+		fs.__mockSetDirectory('/targets/target0')
+		fs.__mockSetDirectory('/targets/target1')
+		// console.log(fs.__printAllFiles())
+
+		env.expectationManager.updateExpectations({
+			step1: literal<Expectation.FileCopy>({
+				id: 'step1',
+				priority: 0,
+				managerId: 'manager0',
+				fromPackages: [{ id: 'package0', expectedContentVersionHash: 'abcd1234' }],
+				type: Expectation.Type.FILE_COPY,
+				statusReport: {
+					label: `Copy file0`,
+					description: '',
+					sendReport: true,
+				},
+				startRequirement: {
+					sources: [getLocalSource('source0', 'file0Source.mp4')],
+				},
+				endRequirement: {
+					targets: [getLocalTarget('target0', 'myFolder/file0Target.mp4')],
+					content: {
+						filePath: 'file0Target.mp4',
+					},
+					version: { type: Expectation.Version.Type.FILE_ON_DISK },
+				},
+				workOptions: {},
+			}),
+			step2: literal<Expectation.FileCopy>({
+				id: 'step2',
+				dependsOnFullfilled: ['step1'], // Depends on step 1
+				priority: 0,
+				managerId: 'manager0',
+				fromPackages: [{ id: 'package0', expectedContentVersionHash: 'abcd1234' }],
+				type: Expectation.Type.FILE_COPY,
+				statusReport: {
+					label: `Copy file0`,
+					description: '',
+					sendReport: true,
+				},
+				startRequirement: {
+					sources: [getLocalTarget('target0', 'myFolder/file0Target.mp4')],
+				},
+				endRequirement: {
+					targets: [getLocalTarget('target1', 'myFolder/file0Target.mp4')],
+					content: {
+						filePath: 'file0Target.mp4',
+					},
+					version: { type: Expectation.Version.Type.FILE_ON_DISK },
+				},
+				workOptions: {},
+			}),
+		})
+
+		// Wait for the job to complete:
+		await waitUntil(() => {
+			expect(env.containerStatuses['target0']).toBeTruthy()
+			expect(env.containerStatuses['target0'].packages['package0']).toBeTruthy()
+			expect(env.containerStatuses['target0'].packages['package0'].packageStatus?.status).toEqual(
+				ExpectedPackageStatusAPI.PackageContainerPackageStatusStatus.READY
+			)
+		}, env.WAIT_JOB_TIME)
+		await waitUntil(() => {
+			expect(env.containerStatuses['target1']).toBeTruthy()
+			expect(env.containerStatuses['target1'].packages['package0']).toBeTruthy()
+			expect(env.containerStatuses['target1'].packages['package0'].packageStatus?.status).toEqual(
+				ExpectedPackageStatusAPI.PackageContainerPackageStatusStatus.READY
+			)
+		}, env.WAIT_JOB_TIME)
+
+		// Check that step 1 and 2 fullfills:
+		expect(env.expectationStatuses['step1'].statusInfo.status).toEqual('fulfilled')
+		expect(env.expectationStatuses['step2'].statusInfo.status).toEqual('fulfilled')
+
+		expect(await fsStat('/targets/target0/myFolder/file0Target.mp4')).toMatchObject({
+			size: 1234,
+		})
+		expect(await fsStat('/targets/target1/myFolder/file0Target.mp4')).toMatchObject({
+			size: 1234,
+		})
+
+		// Now A is removed, so step 1 should be un-fullfilled
+		fs.__mockDeleteFile('/sources/source0/file0Source.mp4')
+
+		// Wait for the step 1 to pick up on the change:
+		await waitUntil(() => {
+			expect(env.expectationStatuses['step1'].statusInfo.status).toMatch(/waiting|new/)
+			expect(env.containerStatuses['target0'].packages['package0'].packageStatus?.status).toEqual(
+				ExpectedPackageStatusAPI.PackageContainerPackageStatusStatus.NOT_FOUND
+			)
+		}, env.WAIT_JOB_TIME)
+
+		// Step 2 should be un-fullfilled, since it depends on step 1.
+		await waitUntil(() => {
+			expect(env.expectationStatuses['step1'].statusInfo.status).toMatch(/waiting|new/)
+			expect(env.expectationStatuses['step2'].statusInfo.status).toMatch(/waiting|new/)
+		}, env.WAIT_JOB_TIME)
+
+		// Source file shows up again:
+		fs.__mockSetFile('/sources/source0/file0Source.mp4', 1234)
+
+		// Now, both steps should fulfill again:
+		await waitUntil(() => {
+			expect(env.expectationStatuses['step1'].statusInfo.status).toBe('fulfilled')
+			expect(env.expectationStatuses['step2'].statusInfo.status).toBe('fulfilled')
+		}, env.WAIT_JOB_TIME)
 	})
 })
 function addCopyFileExpectation(

--- a/tests/internal-tests/src/__tests__/issues.spec.ts
+++ b/tests/internal-tests/src/__tests__/issues.spec.ts
@@ -332,7 +332,7 @@ describe('Handle unhappy paths', () => {
 		// To be written
 		expect(1).toEqual(1)
 	})
-	test.only('When original work step fails, subsequent steps should do so too', async () => {
+	test('When original work step fails, subsequent steps should do so too', async () => {
 		// Step 1: Copy from A to B
 		// Step 2: Copy from B to C
 


### PR DESCRIPTION
This PR fixes a bug where thumbnails & previews lingered as fullfilled for packages that are long gone in Sofie.

**New behaviour:**

1. Expectations that depend on others are un-fulfilled whenever any of the depended-upon expectations are not fullfilled.
2. Thumbnails and Previews (files) are removed when an expectation moves away from being `fulfilled` (using the new property `removePackageOnUnFulfill`).