### PR TITLE
chore: update server-core-integration

### DIFF
--- a/apps/package-manager/packages/generic/src/generateExpectations/nrk/expectations.ts
+++ b/apps/package-manager/packages/generic/src/generateExpectations/nrk/expectations.ts
@@ -92,11 +92,11 @@ function getBasicExpectations(
 		if (shouldBeIgnored(packageWrap)) continue
 
 		// Verify that the expectedPackage has any source and target accessors:
-		const hasAnySourceAccessors = !!packageWrap.sources.find((source) => source.accessors.length > 0)
-		const hasAnyTargetAccessors = !!packageWrap.targets.find((target) => target.accessors.length > 0)
+		const hasAnySourceAccessors = !!packageWrap.sources.find((source) => Object.keys(source.accessors).length > 0)
+		const hasAnyTargetAccessors = !!packageWrap.targets.find((target) => Object.keys(target.accessors).length > 0)
 
 		// No need to generate an expectation if there are no accessors:
-		if (!hasAnySourceAccessors || !hasAnyTargetAccessors) {
+		if (hasAnySourceAccessors || hasAnyTargetAccessors) {
 			if (packageWrap.expectedPackage.type === ExpectedPackage.PackageType.MEDIA_FILE) {
 				if (packageWrap.sources.length === 0) {
 					// If there are no sources defined, just verify that the file exists on the target:

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "node": ">=12.11.0"
     },
     "dependencies": {
-        "@sofie-automation/server-core-integration": "1.50.0-nightly-release50-20230322-103759-dbb6cc5.0"
+        "@sofie-automation/server-core-integration": "1.50.0-nightly-release50-20230615-121624-0fe1787.0"
     },
     "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
     "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -796,10 +796,10 @@
     write-pkg "4.0.0"
     yargs "16.2.0"
 
-"@mos-connection/model@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@mos-connection/model/-/model-3.0.1.tgz#38b41d6848e3af58715ce462c5e55ddf1c5c456f"
-  integrity sha512-e+vrLaghYayuzq5JZABbouofseMMnGmUk0mJcGzCG4aYK3YZ/9JoTe1mJBMecbEiqFQXld8idOHv/9rO8HRy4g==
+"@mos-connection/model@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@mos-connection/model/-/model-3.0.4.tgz#da2648c141b2cd1e3f8fe0653525d8eca142b2f1"
+  integrity sha512-TPA/Y6r0XnlbMp1it5HfGVreUCuVCQdnO2r8PnSfiipdnsJSP9YiSOkNQ17+8oc1qgb8GVCrFRJhkUV8mKuweg==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -1283,12 +1283,12 @@
     semver "^7.3.8"
     shelljs "^0.8.5"
 
-"@sofie-automation/server-core-integration@1.50.0-nightly-release50-20230322-103759-dbb6cc5.0":
-  version "1.50.0-nightly-release50-20230322-103759-dbb6cc5.0"
-  resolved "https://registry.yarnpkg.com/@sofie-automation/server-core-integration/-/server-core-integration-1.50.0-nightly-release50-20230322-103759-dbb6cc5.0.tgz#edf0d8254542861fb3b07fb23f21199387456a5a"
-  integrity sha512-7m4z0qiISuhxjBwgsUJqXXUkgHIIFXa3006ElP/fShH9XOym1daj5LmovUj6qDnPR/49NovYHQyXnhJl5XMPNA==
+"@sofie-automation/server-core-integration@1.50.0-nightly-release50-20230615-121624-0fe1787.0":
+  version "1.50.0-nightly-release50-20230615-121624-0fe1787.0"
+  resolved "https://registry.yarnpkg.com/@sofie-automation/server-core-integration/-/server-core-integration-1.50.0-nightly-release50-20230615-121624-0fe1787.0.tgz#e0deaa2b5e1b925eb59fac4f01ac9e77e81980b6"
+  integrity sha512-dF5zZEeBbgsBZOLPkJQePgWsasi3OX/kPFI4PONtD5ixsg+jAOH/i6hQy7ywjeWtvQsiUK5H6E3uzUmBpEiSHA==
   dependencies:
-    "@sofie-automation/shared-lib" "1.50.0-nightly-release50-20230322-103759-dbb6cc5.0"
+    "@sofie-automation/shared-lib" "1.50.0-nightly-release50-20230615-121624-0fe1787.0"
     ejson "^2.2.3"
     eventemitter3 "^4.0.7"
     faye-websocket "^0.11.4"
@@ -1296,13 +1296,13 @@
     tslib "^2.4.0"
     underscore "^1.13.4"
 
-"@sofie-automation/shared-lib@1.50.0-nightly-release50-20230322-103759-dbb6cc5.0":
-  version "1.50.0-nightly-release50-20230322-103759-dbb6cc5.0"
-  resolved "https://registry.yarnpkg.com/@sofie-automation/shared-lib/-/shared-lib-1.50.0-nightly-release50-20230322-103759-dbb6cc5.0.tgz#6533f36eb4783722f9540756bf6445b173377cbb"
-  integrity sha512-cx9SnK7xO4iVV3AgLO9yZP1rEHoRl2WYzVCuQo6LlRN0qp/LXKt5f2qhBqCSHd9Ef1KF2l3hFhVuYrcX4bkb4g==
+"@sofie-automation/shared-lib@1.50.0-nightly-release50-20230615-121624-0fe1787.0":
+  version "1.50.0-nightly-release50-20230615-121624-0fe1787.0"
+  resolved "https://registry.yarnpkg.com/@sofie-automation/shared-lib/-/shared-lib-1.50.0-nightly-release50-20230615-121624-0fe1787.0.tgz#b1559053d8ef8b56f120293ccb30adb37ecea313"
+  integrity sha512-/oYawa6y/3JIwNo+a+T/OG/6nV4x31wrfMCGrq4Ud4ZU1LGgaR0l2klJlto9K54cF8K/aIPHtP45li+sf9aDkQ==
   dependencies:
-    "@mos-connection/model" "^3.0.1"
-    timeline-state-resolver-types "8.0.0-nightly-release50-20230321-185451-d43f3dc70.0"
+    "@mos-connection/model" "^3.0.4"
+    timeline-state-resolver-types "8.0.0-nightly-release50-20230615-051635-c51460271.0"
     tslib "^2.4.0"
     type-fest "^2.19.0"
 
@@ -9786,12 +9786,12 @@ timed-out@^4.0.1:
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==
 
-timeline-state-resolver-types@8.0.0-nightly-release50-20230321-185451-d43f3dc70.0:
-  version "8.0.0-nightly-release50-20230321-185451-d43f3dc70.0"
-  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-8.0.0-nightly-release50-20230321-185451-d43f3dc70.0.tgz#ee39190551f617be34eca6b7fd274359ded2fffc"
-  integrity sha512-EHt5oMMlbnHZpiVlRAxrzJ56jkcl1mN1MxelhmHxRJugkyLb9W1n7MpVEnIyRKfBABkRrSQTyjWtfMC2Lubtlg==
+timeline-state-resolver-types@8.0.0-nightly-release50-20230615-051635-c51460271.0:
+  version "8.0.0-nightly-release50-20230615-051635-c51460271.0"
+  resolved "https://registry.yarnpkg.com/timeline-state-resolver-types/-/timeline-state-resolver-types-8.0.0-nightly-release50-20230615-051635-c51460271.0.tgz#e9f0fa67133847314d83ae802221812d412346db"
+  integrity sha512-lnWEvFCdNncFInNCmviHDOMrLuIjSjaZ8uBvo7h5fUtVHHRaLiFpudg69bR280ZorSqnEePmJNt90bvXlkrgVw==
   dependencies:
-    tslib "^2.4.1"
+    tslib "^2.5.1"
 
 timers-ext@^0.1.7:
   version "0.1.7"
@@ -9952,10 +9952,15 @@ tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
-tslib@^2.3.0, tslib@^2.4.1:
+tslib@^2.3.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+
+tslib@^2.5.1:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.3.tgz#24944ba2d990940e6e982c4bea147aba80209913"
+  integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==
 
 tsscmp@1.0.6:
   version "1.0.6"


### PR DESCRIPTION
Updated server-core-integration to be using correct typings following https://github.com/nrkno/sofie-core/pull/906

There is also a fix for a type error reported by typescript in vscode (it defaulted to typescript 5.1, rather than the 4.9 in the project).
It was reporting ` Operator '>' cannot be applied to types 'Any' and 'number' `, which looks like an accurate error based on the property definition `accessors: { [accessorId: string]: AccessorOnPackage.Any }`

The line below was to make the tests pass, so I'm not 100% sure of it