### PR TITLE
Hotfix: v1.42.1

### DIFF
--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -85,5 +85,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: deploy/*
-          prerelease: contains(github.ref, '-')
+          prerelease: ${{ contains(github.ref, '-') }}
           fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.4](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.1-alpha.3...v1.42.1-alpha.4) (2023-06-19)
+
+
+### Bug Fixes
+
+* remove version reporting ([ac0cd46](https://github.com/nrkno/tv-automation-package-manager/commit/ac0cd4684a5709dfbb6e1eda268d42e446d67967))
+
+
+
+
+
 ## [1.42.1-alpha.3](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.1-alpha.2...v1.42.1-alpha.3) (2023-06-19)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.3](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.1-alpha.2...v1.42.1-alpha.3) (2023-06-19)
+
+
+### Bug Fixes
+
+* package.json asset build in pkg ([c546b5f](https://github.com/nrkno/tv-automation-package-manager/commit/c546b5fd6457e7b30381f28e4f802b4f385a3348))
+
+
+
+
+
 ## [1.42.1-alpha.2](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.1-alpha.1...v1.42.1-alpha.2) (2023-06-19)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
+
+
+### Bug Fixes
+
+* URL handling was broken, because it treated URLs as file paths ([827a939](https://github.com/nrkno/tv-automation-package-manager/commit/827a93961e9647927aef7970af8babbab028a29e))
+
+
+
+
+
 # [1.42.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0-alpha.5...v1.42.0) (2023-05-10)
 
 **Note:** Version bump only for package package-manager-monorepo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.1](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.1-alpha.0...v1.42.1-alpha.1) (2023-06-19)
+
+**Note:** Version bump only for package package-manager-monorepo
+
+
+
+
+
 ## [1.42.1-alpha.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.2](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.1-alpha.1...v1.42.1-alpha.2) (2023-06-19)
+
+
+### Bug Fixes
+
+* version printout on start ([c4b11bd](https://github.com/nrkno/tv-automation-package-manager/commit/c4b11bd454442504442ec679c9fc709faa16b263))
+
+
+
+
+
 ## [1.42.1-alpha.1](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.1-alpha.0...v1.42.1-alpha.1) (2023-06-19)
 
 **Note:** Version bump only for package package-manager-monorepo

--- a/apps/appcontainer-node/app/CHANGELOG.md
+++ b/apps/appcontainer-node/app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
+
+**Note:** Version bump only for package @appcontainer-node/app
+
+
+
+
+
 # [1.42.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0-alpha.5...v1.42.0) (2023-05-10)
 
 **Note:** Version bump only for package @appcontainer-node/app

--- a/apps/appcontainer-node/app/package.json
+++ b/apps/appcontainer-node/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@appcontainer-node/app",
-    "version": "1.42.0",
+    "version": "1.42.1-alpha.0",
     "description": "AppContainer-Node.js",
     "private": true,
     "scripts": {
@@ -14,7 +14,7 @@
         "nexe": "^3.3.7"
     },
     "dependencies": {
-        "@appcontainer-node/generic": "1.42.0"
+        "@appcontainer-node/generic": "1.42.1-alpha.0"
     },
     "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
     "engines": {

--- a/apps/appcontainer-node/packages/generic/CHANGELOG.md
+++ b/apps/appcontainer-node/packages/generic/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
+
+**Note:** Version bump only for package @appcontainer-node/generic
+
+
+
+
+
 # [1.42.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0-alpha.5...v1.42.0) (2023-05-10)
 
 **Note:** Version bump only for package @appcontainer-node/generic

--- a/apps/appcontainer-node/packages/generic/package.json
+++ b/apps/appcontainer-node/packages/generic/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@appcontainer-node/generic",
-    "version": "1.42.0",
+    "version": "1.42.1-alpha.0",
     "private": true,
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -10,8 +10,8 @@
         "__test": "jest"
     },
     "dependencies": {
-        "@sofie-package-manager/api": "1.42.0",
-        "@sofie-package-manager/worker": "1.42.0",
+        "@sofie-package-manager/api": "1.42.1-alpha.0",
+        "@sofie-package-manager/worker": "1.42.1-alpha.0",
         "underscore": "^1.12.0"
     },
     "devDependencies": {

--- a/apps/http-server/app/CHANGELOG.md
+++ b/apps/http-server/app/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.4](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.3...v1.42.1-alpha.4) (2023-06-19)
+
+
+### Bug Fixes
+
+* remove version reporting ([ac0cd46](https://github.com/nrkno/sofie-package-manager/commit/ac0cd4684a5709dfbb6e1eda268d42e446d67967))
+
+
+
+
+
 ## [1.42.1-alpha.3](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.2...v1.42.1-alpha.3) (2023-06-19)
 
 

--- a/apps/http-server/app/CHANGELOG.md
+++ b/apps/http-server/app/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.2](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.1...v1.42.1-alpha.2) (2023-06-19)
+
+
+### Bug Fixes
+
+* version printout on start ([c4b11bd](https://github.com/nrkno/sofie-package-manager/commit/c4b11bd454442504442ec679c9fc709faa16b263))
+
+
+
+
+
 ## [1.42.1-alpha.1](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.0...v1.42.1-alpha.1) (2023-06-19)
 
 **Note:** Version bump only for package @http-server/app

--- a/apps/http-server/app/CHANGELOG.md
+++ b/apps/http-server/app/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.3](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.2...v1.42.1-alpha.3) (2023-06-19)
+
+
+### Bug Fixes
+
+* package.json asset build in pkg ([c546b5f](https://github.com/nrkno/sofie-package-manager/commit/c546b5fd6457e7b30381f28e4f802b4f385a3348))
+
+
+
+
+
 ## [1.42.1-alpha.2](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.1...v1.42.1-alpha.2) (2023-06-19)
 
 

--- a/apps/http-server/app/CHANGELOG.md
+++ b/apps/http-server/app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.1](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.0...v1.42.1-alpha.1) (2023-06-19)
+
+**Note:** Version bump only for package @http-server/app
+
+
+
+
+
 ## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
 
 **Note:** Version bump only for package @http-server/app

--- a/apps/http-server/app/CHANGELOG.md
+++ b/apps/http-server/app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
+
+**Note:** Version bump only for package @http-server/app
+
+
+
+
+
 # [1.42.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0-alpha.5...v1.42.0) (2023-05-10)
 
 **Note:** Version bump only for package @http-server/app

--- a/apps/http-server/app/package.json
+++ b/apps/http-server/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@http-server/app",
-    "version": "1.42.0",
+    "version": "1.42.1-alpha.0",
     "description": "Upload to and serve proxies of packages",
     "private": true,
     "scripts": {
@@ -14,7 +14,7 @@
         "nexe": "^3.3.7"
     },
     "dependencies": {
-        "@http-server/generic": "1.42.0"
+        "@http-server/generic": "1.42.1-alpha.0"
     },
     "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
     "engines": {

--- a/apps/http-server/app/package.json
+++ b/apps/http-server/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@http-server/app",
-    "version": "1.42.1-alpha.2",
+    "version": "1.42.1-alpha.3",
     "description": "Upload to and serve proxies of packages",
     "private": true,
     "scripts": {

--- a/apps/http-server/app/package.json
+++ b/apps/http-server/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@http-server/app",
-    "version": "1.42.1-alpha.3",
+    "version": "1.42.1-alpha.4",
     "description": "Upload to and serve proxies of packages",
     "private": true,
     "scripts": {

--- a/apps/http-server/app/package.json
+++ b/apps/http-server/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@http-server/app",
-    "version": "1.42.1-alpha.0",
+    "version": "1.42.1-alpha.1",
     "description": "Upload to and serve proxies of packages",
     "private": true,
     "scripts": {
@@ -14,7 +14,7 @@
         "nexe": "^3.3.7"
     },
     "dependencies": {
-        "@http-server/generic": "1.42.1-alpha.0"
+        "@http-server/generic": "1.42.1-alpha.1"
     },
     "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
     "engines": {

--- a/apps/http-server/app/package.json
+++ b/apps/http-server/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@http-server/app",
-    "version": "1.42.1-alpha.1",
+    "version": "1.42.1-alpha.2",
     "description": "Upload to and serve proxies of packages",
     "private": true,
     "scripts": {
@@ -14,7 +14,7 @@
         "nexe": "^3.3.7"
     },
     "dependencies": {
-        "@http-server/generic": "1.42.1-alpha.1"
+        "@http-server/generic": "1.42.1-alpha.2"
     },
     "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
     "engines": {

--- a/apps/http-server/app/src/index.ts
+++ b/apps/http-server/app/src/index.ts
@@ -1,7 +1,9 @@
 import { startProcess } from '@http-server/generic'
+import { readFileSync } from 'fs'
+import { join as pathJoin } from 'path'
 /* eslint-disable no-console */
 
-import packageInfo from './../package.json'
+const packageInfo = JSON.parse(readFileSync(pathJoin(__dirname, './../package.json')).toString('utf-8'))
 
 console.log('process started') // This is a message all Sofie processes log upon startup
 console.log(`version: ${packageInfo.version}`)

--- a/apps/http-server/app/src/index.ts
+++ b/apps/http-server/app/src/index.ts
@@ -1,10 +1,5 @@
 import { startProcess } from '@http-server/generic'
-import fs from 'fs'
-import path from 'path'
 /* eslint-disable no-console */
 
-const packageInfo = JSON.parse(fs.readFileSync(path.join(__dirname, './../package.json')).toString('utf-8'))
-
 console.log('process started') // This is a message all Sofie processes log upon startup
-console.log(`version: ${packageInfo.version}`)
 startProcess().catch(console.error)

--- a/apps/http-server/app/src/index.ts
+++ b/apps/http-server/app/src/index.ts
@@ -1,9 +1,9 @@
 import { startProcess } from '@http-server/generic'
-import { readFileSync } from 'fs'
-import { join as pathJoin } from 'path'
+import fs from 'fs'
+import path from 'path'
 /* eslint-disable no-console */
 
-const packageInfo = JSON.parse(readFileSync(pathJoin(__dirname, './../package.json')).toString('utf-8'))
+const packageInfo = JSON.parse(fs.readFileSync(path.join(__dirname, './../package.json')).toString('utf-8'))
 
 console.log('process started') // This is a message all Sofie processes log upon startup
 console.log(`version: ${packageInfo.version}`)

--- a/apps/http-server/packages/generic/CHANGELOG.md
+++ b/apps/http-server/packages/generic/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
+
+**Note:** Version bump only for package @http-server/generic
+
+
+
+
+
 # [1.42.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0-alpha.5...v1.42.0) (2023-05-10)
 
 **Note:** Version bump only for package @http-server/generic

--- a/apps/http-server/packages/generic/CHANGELOG.md
+++ b/apps/http-server/packages/generic/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.2](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.1...v1.42.1-alpha.2) (2023-06-19)
+
+
+### Bug Fixes
+
+* version printout on start ([c4b11bd](https://github.com/nrkno/sofie-package-manager/commit/c4b11bd454442504442ec679c9fc709faa16b263))
+
+
+
+
+
 ## [1.42.1-alpha.1](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.0...v1.42.1-alpha.1) (2023-06-19)
 
 **Note:** Version bump only for package @http-server/generic

--- a/apps/http-server/packages/generic/CHANGELOG.md
+++ b/apps/http-server/packages/generic/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.1](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.0...v1.42.1-alpha.1) (2023-06-19)
+
+**Note:** Version bump only for package @http-server/generic
+
+
+
+
+
 ## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
 
 **Note:** Version bump only for package @http-server/generic

--- a/apps/http-server/packages/generic/package.json
+++ b/apps/http-server/packages/generic/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@http-server/generic",
-    "version": "1.42.1-alpha.0",
+    "version": "1.42.1-alpha.1",
     "private": true,
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/apps/http-server/packages/generic/package.json
+++ b/apps/http-server/packages/generic/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@http-server/generic",
-    "version": "1.42.0",
+    "version": "1.42.1-alpha.0",
     "private": true,
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     },
     "dependencies": {
         "@koa/cors": "^4.0.0",
-        "@sofie-package-manager/api": "1.42.0",
+        "@sofie-package-manager/api": "1.42.1-alpha.0",
         "koa": "^2.14.1",
         "koa-bodyparser": "^4.3.0",
         "koa-range": "^0.3.0",

--- a/apps/http-server/packages/generic/package.json
+++ b/apps/http-server/packages/generic/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@http-server/generic",
-    "version": "1.42.1-alpha.1",
+    "version": "1.42.1-alpha.2",
     "private": true,
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/apps/http-server/packages/generic/src/lib.ts
+++ b/apps/http-server/packages/generic/src/lib.ts
@@ -1,5 +1,15 @@
 import Koa from 'koa'
 import Router from 'koa-router'
+import { Readable, Writable } from 'stream'
 
 export type CTX = Koa.ParameterizedContext<any, Router.IRouterParamContext<any, any>>
 export type CTXPost = Koa.ParameterizedContext<any, Router.IRouterParamContext<any, any>>
+
+export async function asyncPipe(readable: Readable, writable: Writable): Promise<void> {
+	return new Promise((resolve) => {
+		readable.pipe(writable)
+		readable.on('end', () => {
+			resolve()
+		})
+	})
+}

--- a/apps/http-server/packages/generic/src/storage/fileStorage.ts
+++ b/apps/http-server/packages/generic/src/storage/fileStorage.ts
@@ -4,10 +4,10 @@ import { promisify } from 'util'
 import mime from 'mime-types'
 import mkdirp from 'mkdirp'
 import prettyBytes from 'pretty-bytes'
-import { CTX, CTXPost } from '../lib'
+import { asyncPipe, CTX, CTXPost } from '../lib'
 import { HTTPServerConfig, LoggerInstance } from '@sofie-package-manager/api'
 import { BadResponse, Storage } from './storage'
-import { Readable, Writable } from 'stream'
+import { Readable } from 'stream'
 
 // Note: Explicit types here, due to that for some strange reason, promisify wont pass through the correct typings.
 const fsStat = promisify(fs.stat)
@@ -17,15 +17,6 @@ const fsRmDir = promisify(fs.rmdir)
 const fsReaddir = promisify(fs.readdir)
 const fsLstat = promisify(fs.lstat)
 const fsWriteFile = promisify(fs.writeFile)
-
-async function asyncPipe(readable: Readable, writable: Writable): Promise<void> {
-	return new Promise((resolve) => {
-		readable.pipe(writable)
-		readable.on('end', () => {
-			resolve()
-		})
-	})
-}
 
 type FileInfo = {
 	found: true

--- a/apps/package-manager/app/CHANGELOG.md
+++ b/apps/package-manager/app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
+
+**Note:** Version bump only for package @package-manager/app
+
+
+
+
+
 # [1.42.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0-alpha.5...v1.42.0) (2023-05-10)
 
 **Note:** Version bump only for package @package-manager/app

--- a/apps/package-manager/app/package.json
+++ b/apps/package-manager/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@package-manager/app",
-    "version": "1.42.0",
+    "version": "1.42.1-alpha.0",
     "private": true,
     "scripts": {
         "build": "yarn rimraf dist && yarn build:main",
@@ -13,7 +13,7 @@
         "nexe": "^3.3.7"
     },
     "dependencies": {
-        "@package-manager/generic": "1.42.0"
+        "@package-manager/generic": "1.42.1-alpha.0"
     },
     "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
     "engines": {

--- a/apps/package-manager/packages/generic/CHANGELOG.md
+++ b/apps/package-manager/packages/generic/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
+
+**Note:** Version bump only for package @package-manager/generic
+
+
+
+
+
 # [1.42.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0-alpha.5...v1.42.0) (2023-05-10)
 
 **Note:** Version bump only for package @package-manager/generic

--- a/apps/package-manager/packages/generic/package.json
+++ b/apps/package-manager/packages/generic/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@package-manager/generic",
-    "version": "1.42.0",
+    "version": "1.42.1-alpha.0",
     "private": true,
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -13,9 +13,9 @@
         "@sofie-automation/server-core-integration": "*"
     },
     "dependencies": {
-        "@sofie-package-manager/api": "1.42.0",
-        "@sofie-package-manager/expectation-manager": "1.42.0",
-        "@sofie-package-manager/worker": "1.42.0",
+        "@sofie-package-manager/api": "1.42.1-alpha.0",
+        "@sofie-package-manager/expectation-manager": "1.42.1-alpha.0",
+        "@sofie-package-manager/worker": "1.42.1-alpha.0",
         "chokidar": "^3.5.1",
         "data-store": "^4.0.3",
         "deep-extend": "^0.6.0",

--- a/apps/quantel-http-transformer-proxy/app/CHANGELOG.md
+++ b/apps/quantel-http-transformer-proxy/app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
+
+**Note:** Version bump only for package @quantel-http-transformer-proxy/app
+
+
+
+
+
 # [1.42.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0-alpha.5...v1.42.0) (2023-05-10)
 
 **Note:** Version bump only for package @quantel-http-transformer-proxy/app

--- a/apps/quantel-http-transformer-proxy/app/package.json
+++ b/apps/quantel-http-transformer-proxy/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@quantel-http-transformer-proxy/app",
-    "version": "1.42.0",
+    "version": "1.42.1-alpha.0",
     "description": "Proxy for a Quantel HTTP Transformer",
     "private": true,
     "scripts": {
@@ -13,7 +13,7 @@
         "nexe": "^3.3.7"
     },
     "dependencies": {
-        "@quantel-http-transformer-proxy/generic": "1.42.0"
+        "@quantel-http-transformer-proxy/generic": "1.42.1-alpha.0"
     },
     "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
     "engines": {

--- a/apps/quantel-http-transformer-proxy/packages/generic/CHANGELOG.md
+++ b/apps/quantel-http-transformer-proxy/packages/generic/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
+
+**Note:** Version bump only for package @quantel-http-transformer-proxy/generic
+
+
+
+
+
 # [1.42.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0-alpha.5...v1.42.0) (2023-05-10)
 
 **Note:** Version bump only for package @quantel-http-transformer-proxy/generic

--- a/apps/quantel-http-transformer-proxy/packages/generic/package.json
+++ b/apps/quantel-http-transformer-proxy/packages/generic/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@quantel-http-transformer-proxy/generic",
-    "version": "1.42.0",
+    "version": "1.42.1-alpha.0",
     "private": true,
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -12,7 +12,7 @@
     "dependencies": {
         "@koa/cors": "^4.0.0",
         "@koa/multer": "3.0.0",
-        "@sofie-package-manager/api": "1.42.0",
+        "@sofie-package-manager/api": "1.42.1-alpha.0",
         "got": "^11.8.6",
         "koa": "^2.14.1",
         "koa-bodyparser": "^4.3.0",

--- a/apps/single-app/app/CHANGELOG.md
+++ b/apps/single-app/app/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.4](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.3...v1.42.1-alpha.4) (2023-06-19)
+
+
+### Bug Fixes
+
+* remove version reporting ([ac0cd46](https://github.com/nrkno/sofie-package-manager/commit/ac0cd4684a5709dfbb6e1eda268d42e446d67967))
+
+
+
+
+
 ## [1.42.1-alpha.3](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.2...v1.42.1-alpha.3) (2023-06-19)
 
 

--- a/apps/single-app/app/CHANGELOG.md
+++ b/apps/single-app/app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
+
+**Note:** Version bump only for package @single-app/app
+
+
+
+
+
 # [1.42.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0-alpha.5...v1.42.0) (2023-05-10)
 
 **Note:** Version bump only for package @single-app/app

--- a/apps/single-app/app/CHANGELOG.md
+++ b/apps/single-app/app/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.3](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.2...v1.42.1-alpha.3) (2023-06-19)
+
+
+### Bug Fixes
+
+* package.json asset build in pkg ([c546b5f](https://github.com/nrkno/sofie-package-manager/commit/c546b5fd6457e7b30381f28e4f802b4f385a3348))
+
+
+
+
+
 ## [1.42.1-alpha.2](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.1...v1.42.1-alpha.2) (2023-06-19)
 
 

--- a/apps/single-app/app/CHANGELOG.md
+++ b/apps/single-app/app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.1](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.0...v1.42.1-alpha.1) (2023-06-19)
+
+**Note:** Version bump only for package @single-app/app
+
+
+
+
+
 ## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
 
 **Note:** Version bump only for package @single-app/app

--- a/apps/single-app/app/CHANGELOG.md
+++ b/apps/single-app/app/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.2](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.1...v1.42.1-alpha.2) (2023-06-19)
+
+
+### Bug Fixes
+
+* version printout on start ([c4b11bd](https://github.com/nrkno/sofie-package-manager/commit/c4b11bd454442504442ec679c9fc709faa16b263))
+
+
+
+
+
 ## [1.42.1-alpha.1](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.0...v1.42.1-alpha.1) (2023-06-19)
 
 **Note:** Version bump only for package @single-app/app

--- a/apps/single-app/app/package.json
+++ b/apps/single-app/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@single-app/app",
-    "version": "1.42.1-alpha.2",
+    "version": "1.42.1-alpha.3",
     "description": "Package Manager, http-proxy etc.. all in one application",
     "private": true,
     "scripts": {

--- a/apps/single-app/app/package.json
+++ b/apps/single-app/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@single-app/app",
-    "version": "1.42.0",
+    "version": "1.42.1-alpha.0",
     "description": "Package Manager, http-proxy etc.. all in one application",
     "private": true,
     "scripts": {
@@ -14,13 +14,13 @@
         "nexe": "^3.3.7"
     },
     "dependencies": {
-        "@appcontainer-node/generic": "1.42.0",
-        "@http-server/generic": "1.42.0",
-        "@package-manager/generic": "1.42.0",
-        "@quantel-http-transformer-proxy/generic": "1.42.0",
-        "@sofie-package-manager/api": "1.42.0",
-        "@sofie-package-manager/worker": "1.42.0",
-        "@sofie-package-manager/workforce": "1.42.0",
+        "@appcontainer-node/generic": "1.42.1-alpha.0",
+        "@http-server/generic": "1.42.1-alpha.0",
+        "@package-manager/generic": "1.42.1-alpha.0",
+        "@quantel-http-transformer-proxy/generic": "1.42.1-alpha.0",
+        "@sofie-package-manager/api": "1.42.1-alpha.0",
+        "@sofie-package-manager/worker": "1.42.1-alpha.0",
+        "@sofie-package-manager/workforce": "1.42.1-alpha.0",
         "underscore": "^1.12.0"
     },
     "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",

--- a/apps/single-app/app/package.json
+++ b/apps/single-app/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@single-app/app",
-    "version": "1.42.1-alpha.3",
+    "version": "1.42.1-alpha.4",
     "description": "Package Manager, http-proxy etc.. all in one application",
     "private": true,
     "scripts": {

--- a/apps/single-app/app/package.json
+++ b/apps/single-app/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@single-app/app",
-    "version": "1.42.1-alpha.0",
+    "version": "1.42.1-alpha.1",
     "description": "Package Manager, http-proxy etc.. all in one application",
     "private": true,
     "scripts": {
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@appcontainer-node/generic": "1.42.1-alpha.0",
-        "@http-server/generic": "1.42.1-alpha.0",
+        "@http-server/generic": "1.42.1-alpha.1",
         "@package-manager/generic": "1.42.1-alpha.0",
         "@quantel-http-transformer-proxy/generic": "1.42.1-alpha.0",
         "@sofie-package-manager/api": "1.42.1-alpha.0",

--- a/apps/single-app/app/package.json
+++ b/apps/single-app/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@single-app/app",
-    "version": "1.42.1-alpha.1",
+    "version": "1.42.1-alpha.2",
     "description": "Package Manager, http-proxy etc.. all in one application",
     "private": true,
     "scripts": {
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@appcontainer-node/generic": "1.42.1-alpha.0",
-        "@http-server/generic": "1.42.1-alpha.1",
+        "@http-server/generic": "1.42.1-alpha.2",
         "@package-manager/generic": "1.42.1-alpha.0",
         "@quantel-http-transformer-proxy/generic": "1.42.1-alpha.0",
         "@sofie-package-manager/api": "1.42.1-alpha.0",

--- a/apps/single-app/app/src/index.ts
+++ b/apps/single-app/app/src/index.ts
@@ -1,8 +1,8 @@
 import { startSingleApp } from './singleApp'
-import { readFileSync } from 'fs'
-import { join as pathJoin } from 'path'
+import fs from 'fs'
+import path from 'path'
 
-const packageInfo = JSON.parse(readFileSync(pathJoin(__dirname, './../package.json')).toString('utf-8'))
+const packageInfo = JSON.parse(fs.readFileSync(path.join(__dirname, './../package.json')).toString('utf-8'))
 
 // eslint-disable-next-line no-console
 console.log('process started') // This is a message all Sofie processes log upon startup

--- a/apps/single-app/app/src/index.ts
+++ b/apps/single-app/app/src/index.ts
@@ -1,12 +1,6 @@
 import { startSingleApp } from './singleApp'
-import fs from 'fs'
-import path from 'path'
-
-const packageInfo = JSON.parse(fs.readFileSync(path.join(__dirname, './../package.json')).toString('utf-8'))
 
 // eslint-disable-next-line no-console
 console.log('process started') // This is a message all Sofie processes log upon startup
-// eslint-disable-next-line no-console
-console.log(`version: ${packageInfo.version}`)
 // eslint-disable-next-line no-console
 startSingleApp().catch(console.error)

--- a/apps/single-app/app/src/index.ts
+++ b/apps/single-app/app/src/index.ts
@@ -1,6 +1,8 @@
 import { startSingleApp } from './singleApp'
+import { readFileSync } from 'fs'
+import { join as pathJoin } from 'path'
 
-import packageInfo from './../package.json'
+const packageInfo = JSON.parse(readFileSync(pathJoin(__dirname, './../package.json')).toString('utf-8'))
 
 // eslint-disable-next-line no-console
 console.log('process started') // This is a message all Sofie processes log upon startup

--- a/apps/worker/app/CHANGELOG.md
+++ b/apps/worker/app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
+
+**Note:** Version bump only for package @worker/app
+
+
+
+
+
 # [1.42.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0-alpha.5...v1.42.0) (2023-05-10)
 
 **Note:** Version bump only for package @worker/app

--- a/apps/worker/app/package.json
+++ b/apps/worker/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@worker/app",
-    "version": "1.42.0",
+    "version": "1.42.1-alpha.0",
     "description": "Boilerplace",
     "private": true,
     "scripts": {
@@ -15,7 +15,7 @@
         "nexe": "^3.3.7"
     },
     "dependencies": {
-        "@worker/generic": "1.42.0"
+        "@worker/generic": "1.42.1-alpha.0"
     },
     "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
     "engines": {

--- a/apps/worker/packages/generic/CHANGELOG.md
+++ b/apps/worker/packages/generic/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
+
+**Note:** Version bump only for package @worker/generic
+
+
+
+
+
 # [1.42.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0-alpha.5...v1.42.0) (2023-05-10)
 
 **Note:** Version bump only for package @worker/generic

--- a/apps/worker/packages/generic/package.json
+++ b/apps/worker/packages/generic/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@worker/generic",
-    "version": "1.42.0",
+    "version": "1.42.1-alpha.0",
     "private": true,
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -10,8 +10,8 @@
         "__test": "jest"
     },
     "dependencies": {
-        "@sofie-package-manager/api": "1.42.0",
-        "@sofie-package-manager/worker": "1.42.0"
+        "@sofie-package-manager/api": "1.42.1-alpha.0",
+        "@sofie-package-manager/worker": "1.42.1-alpha.0"
     },
     "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
     "engines": {

--- a/apps/workforce/app/CHANGELOG.md
+++ b/apps/workforce/app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
+
+**Note:** Version bump only for package @workforce/app
+
+
+
+
+
 # [1.42.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0-alpha.5...v1.42.0) (2023-05-10)
 
 **Note:** Version bump only for package @workforce/app

--- a/apps/workforce/app/package.json
+++ b/apps/workforce/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@workforce/app",
-    "version": "1.42.0",
+    "version": "1.42.1-alpha.0",
     "description": "Boilerplace",
     "private": true,
     "scripts": {
@@ -14,7 +14,7 @@
         "nexe": "^3.3.7"
     },
     "dependencies": {
-        "@workforce/generic": "1.42.0"
+        "@workforce/generic": "1.42.1-alpha.0"
     },
     "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
     "engines": {

--- a/apps/workforce/packages/generic/CHANGELOG.md
+++ b/apps/workforce/packages/generic/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
+
+**Note:** Version bump only for package @workforce/generic
+
+
+
+
+
 # [1.42.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0-alpha.5...v1.42.0) (2023-05-10)
 
 **Note:** Version bump only for package @workforce/generic

--- a/apps/workforce/packages/generic/package.json
+++ b/apps/workforce/packages/generic/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@workforce/generic",
-    "version": "1.42.0",
+    "version": "1.42.1-alpha.0",
     "private": true,
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -10,8 +10,8 @@
         "__test": "jest"
     },
     "dependencies": {
-        "@sofie-package-manager/api": "1.42.0",
-        "@sofie-package-manager/workforce": "1.42.0"
+        "@sofie-package-manager/api": "1.42.1-alpha.0",
+        "@sofie-package-manager/workforce": "1.42.1-alpha.0"
     },
     "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
     "engines": {

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
     "apps/**",
     "tests/**"
   ],
-  "version": "1.42.1-alpha.2",
+  "version": "1.42.1-alpha.3",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
     "apps/**",
     "tests/**"
   ],
-  "version": "1.42.1-alpha.1",
+  "version": "1.42.1-alpha.2",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
     "apps/**",
     "tests/**"
   ],
-  "version": "1.42.0",
+  "version": "1.42.1-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
     "apps/**",
     "tests/**"
   ],
-  "version": "1.42.1-alpha.0",
+  "version": "1.42.1-alpha.1",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
     "apps/**",
     "tests/**"
   ],
-  "version": "1.42.1-alpha.3",
+  "version": "1.42.1-alpha.4",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/shared/packages/api/CHANGELOG.md
+++ b/shared/packages/api/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
+
+
+### Bug Fixes
+
+* URL handling was broken, because it treated URLs as file paths ([827a939](https://github.com/nrkno/sofie-package-manager/commit/827a93961e9647927aef7970af8babbab028a29e))
+
+
+
+
+
 # [1.42.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0-alpha.5...v1.42.0) (2023-05-10)
 
 **Note:** Version bump only for package @sofie-package-manager/api

--- a/shared/packages/api/package.json
+++ b/shared/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sofie-package-manager/api",
-    "version": "1.42.0",
+    "version": "1.42.1-alpha.0",
     "main": "dist/index",
     "types": "dist/index",
     "files": [

--- a/shared/packages/expectationManager/CHANGELOG.md
+++ b/shared/packages/expectationManager/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
+
+**Note:** Version bump only for package @sofie-package-manager/expectation-manager
+
+
+
+
+
 # [1.42.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0-alpha.5...v1.42.0) (2023-05-10)
 
 **Note:** Version bump only for package @sofie-package-manager/expectation-manager

--- a/shared/packages/expectationManager/package.json
+++ b/shared/packages/expectationManager/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sofie-package-manager/expectation-manager",
-    "version": "1.42.0",
+    "version": "1.42.1-alpha.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "license": "MIT",
@@ -13,8 +13,8 @@
         "node": ">=14.18.0"
     },
     "dependencies": {
-        "@sofie-package-manager/api": "1.42.0",
-        "@sofie-package-manager/worker": "1.42.0",
+        "@sofie-package-manager/api": "1.42.1-alpha.0",
+        "@sofie-package-manager/worker": "1.42.1-alpha.0",
         "@supercharge/promise-pool": "^2.4.0",
         "underscore": "^1.12.0"
     },

--- a/shared/packages/worker/CHANGELOG.md
+++ b/shared/packages/worker/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
+
+
+### Bug Fixes
+
+* URL handling was broken, because it treated URLs as file paths ([827a939](https://github.com/nrkno/sofie-package-manager/commit/827a93961e9647927aef7970af8babbab028a29e))
+
+
+
+
+
 # [1.42.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0-alpha.5...v1.42.0) (2023-05-10)
 
 **Note:** Version bump only for package @sofie-package-manager/worker

--- a/shared/packages/worker/package.json
+++ b/shared/packages/worker/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sofie-package-manager/worker",
-    "version": "1.42.0",
+    "version": "1.42.1-alpha.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "license": "MIT",
@@ -18,7 +18,7 @@
         "@types/tmp": "~0.2.2"
     },
     "dependencies": {
-        "@sofie-package-manager/api": "1.42.0",
+        "@sofie-package-manager/api": "1.42.1-alpha.0",
         "abort-controller": "^3.0.0",
         "atem-connection": "^3.2.0",
         "chokidar": "^3.5.1",

--- a/shared/packages/workforce/CHANGELOG.md
+++ b/shared/packages/workforce/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
+
+**Note:** Version bump only for package @sofie-package-manager/workforce
+
+
+
+
+
 # [1.42.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0-alpha.5...v1.42.0) (2023-05-10)
 
 **Note:** Version bump only for package @sofie-package-manager/workforce

--- a/shared/packages/workforce/package.json
+++ b/shared/packages/workforce/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sofie-package-manager/workforce",
-    "version": "1.42.0",
+    "version": "1.42.1-alpha.0",
     "main": "dist/index",
     "types": "dist/index",
     "files": [
@@ -13,7 +13,7 @@
         "__test": "jest"
     },
     "dependencies": {
-        "@sofie-package-manager/api": "1.42.0"
+        "@sofie-package-manager/api": "1.42.1-alpha.0"
     },
     "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json",
     "engines": {

--- a/tests/internal-tests/CHANGELOG.md
+++ b/tests/internal-tests/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
+
+**Note:** Version bump only for package @tests/internal-tests
+
+
+
+
+
 # [1.42.0](https://github.com/nrkno/tv-automation-package-manager/compare/v1.42.0-alpha.5...v1.42.0) (2023-05-10)
 
 **Note:** Version bump only for package @tests/internal-tests

--- a/tests/internal-tests/CHANGELOG.md
+++ b/tests/internal-tests/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.2](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.1...v1.42.1-alpha.2) (2023-06-19)
+
+**Note:** Version bump only for package @tests/internal-tests
+
+
+
+
+
 ## [1.42.1-alpha.1](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.0...v1.42.1-alpha.1) (2023-06-19)
 
 **Note:** Version bump only for package @tests/internal-tests

--- a/tests/internal-tests/CHANGELOG.md
+++ b/tests/internal-tests/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.42.1-alpha.1](https://github.com/nrkno/sofie-package-manager/compare/v1.42.1-alpha.0...v1.42.1-alpha.1) (2023-06-19)
+
+**Note:** Version bump only for package @tests/internal-tests
+
+
+
+
+
 ## [1.42.1-alpha.0](https://github.com/nrkno/sofie-package-manager/compare/v1.42.0...v1.42.1-alpha.0) (2023-06-09)
 
 **Note:** Version bump only for package @tests/internal-tests

--- a/tests/internal-tests/package.json
+++ b/tests/internal-tests/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tests/internal-tests",
-    "version": "1.42.1-alpha.0",
+    "version": "1.42.1-alpha.1",
     "description": "Internal tests",
     "private": true,
     "scripts": {
@@ -14,7 +14,7 @@
         "tv-automation-quantel-gateway-client": "^3.1.7"
     },
     "dependencies": {
-        "@http-server/generic": "1.42.1-alpha.0",
+        "@http-server/generic": "1.42.1-alpha.1",
         "@package-manager/generic": "1.42.1-alpha.0",
         "@sofie-package-manager/api": "1.42.1-alpha.0",
         "@sofie-package-manager/expectation-manager": "1.42.1-alpha.0",

--- a/tests/internal-tests/package.json
+++ b/tests/internal-tests/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tests/internal-tests",
-    "version": "1.42.1-alpha.1",
+    "version": "1.42.1-alpha.2",
     "description": "Internal tests",
     "private": true,
     "scripts": {
@@ -14,7 +14,7 @@
         "tv-automation-quantel-gateway-client": "^3.1.7"
     },
     "dependencies": {
-        "@http-server/generic": "1.42.1-alpha.1",
+        "@http-server/generic": "1.42.1-alpha.2",
         "@package-manager/generic": "1.42.1-alpha.0",
         "@sofie-package-manager/api": "1.42.1-alpha.0",
         "@sofie-package-manager/expectation-manager": "1.42.1-alpha.0",

--- a/tests/internal-tests/package.json
+++ b/tests/internal-tests/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tests/internal-tests",
-    "version": "1.42.0",
+    "version": "1.42.1-alpha.0",
     "description": "Internal tests",
     "private": true,
     "scripts": {
@@ -14,12 +14,12 @@
         "tv-automation-quantel-gateway-client": "^3.1.7"
     },
     "dependencies": {
-        "@http-server/generic": "1.42.0",
-        "@package-manager/generic": "1.42.0",
-        "@sofie-package-manager/api": "1.42.0",
-        "@sofie-package-manager/expectation-manager": "1.42.0",
-        "@sofie-package-manager/worker": "1.42.0",
-        "@sofie-package-manager/workforce": "1.42.0",
+        "@http-server/generic": "1.42.1-alpha.0",
+        "@package-manager/generic": "1.42.1-alpha.0",
+        "@sofie-package-manager/api": "1.42.1-alpha.0",
+        "@sofie-package-manager/expectation-manager": "1.42.1-alpha.0",
+        "@sofie-package-manager/worker": "1.42.1-alpha.0",
+        "@sofie-package-manager/workforce": "1.42.1-alpha.0",
         "underscore": "^1.12.0",
         "windows-network-drive": "^4.0.1"
     },

--- a/tests/internal-tests/src/__tests__/issues.spec.ts
+++ b/tests/internal-tests/src/__tests__/issues.spec.ts
@@ -35,7 +35,7 @@ const fsExists = async (filePath: string) => {
 // const fsStat = promisify(fs.stat)
 
 // this test can be a bit slower in CI sometimes
-jest.setTimeout(10000)
+jest.setTimeout(30000)
 
 describe('Handle unhappy paths', () => {
 	let env: TestEnviromnent


### PR DESCRIPTION
This is a hotfix for two problems:
1. PM HTTP Proxy Server (used for serving assets) truncates uploads in some conditions
2. HTTP accessor can mangle the URL of objects, making them inaccessible