### PR TITLE
feat: generate audio waveform images for audio-only files

### DIFF
--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/lib.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/lib.ts
@@ -338,14 +338,21 @@ interface ThumbnailMetadata {
 	}
 }
 /** Returns arguments for FFMpeg to generate a thumbnail image file */
-export function thumbnailFFMpegArguments(input: string, metadata: ThumbnailMetadata, seekTimeCode?: string): string[] {
+export function thumbnailFFMpegArguments(
+	input: string,
+	metadata: ThumbnailMetadata,
+	seekTimeCode?: string,
+	hasVideoStream?: boolean
+): string[] {
 	return [
 		'-hide_banner',
-		seekTimeCode ? `-ss ${seekTimeCode}` : undefined,
+		hasVideoStream && seekTimeCode ? `-ss ${seekTimeCode}` : undefined,
 		`-i "${input}"`,
 		`-f image2`,
 		'-frames:v 1',
-		`-vf ${!seekTimeCode ? 'thumbnail,' : ''}scale=${metadata.version.width}:${metadata.version.height}`,
+		hasVideoStream
+			? `-vf ${!seekTimeCode ? 'thumbnail,' : ''}scale=${metadata.version.width}:${metadata.version.height}` // Creates a thumbnail of the video.
+			: '-filter_complex "showwavespic=s=640x240:split_channels=1"', // Creates an image of the audio waveform.
 		'-threads 1',
 	].filter(Boolean) as string[] // remove undefined values
 }

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/lib.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/lib.ts
@@ -352,7 +352,7 @@ export function thumbnailFFMpegArguments(
 		'-frames:v 1',
 		hasVideoStream
 			? `-vf ${!seekTimeCode ? 'thumbnail,' : ''}scale=${metadata.version.width}:${metadata.version.height}` // Creates a thumbnail of the video.
-			: '-filter_complex "showwavespic=s=640x240:split_channels=1"', // Creates an image of the audio waveform.
+			: '-filter_complex "showwavespic=s=640x240:split_channels=1:colors=white"', // Creates an image of the audio waveform.
 		'-threads 1',
 	].filter(Boolean) as string[] // remove undefined values
 }

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/mediaFilePreview.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/mediaFilePreview.ts
@@ -28,8 +28,6 @@ import {
 } from './lib'
 import { FFMpegProcess, spawnFFMpeg } from './lib/ffmpeg'
 import { WindowsWorker } from '../windowsWorker'
-import { scanWithFFProbe, FFProbeScanResult } from './lib/scan'
-import { CancelablePromise } from '../../../lib/cancelablePromise'
 
 /**
  * Generates a low-res preview video of a source video file, and stores the resulting file into the target PackageContainer
@@ -180,11 +178,9 @@ export const MediaFilePreview: ExpectationWindowsHandler = {
 				throw new Error(`Target AccessHandler type is wrong`)
 
 			let ffMpegProcess: FFMpegProcess | undefined
-			let ffProbeProcess: CancelablePromise<any> | undefined
 			const workInProgress = new WorkInProgress({ workLabel: 'Generating preview' }, async () => {
 				// On cancel
 				ffMpegProcess?.cancel()
-				ffProbeProcess?.cancel()
 			}).do(async () => {
 				const tryReadPackage = await sourceHandle.checkPackageReadAccess()
 				if (!tryReadPackage.success) throw new Error(tryReadPackage.reason.tech)
@@ -222,24 +218,6 @@ export const MediaFilePreview: ExpectationWindowsHandler = {
 				} else {
 					assertNever(sourceHandle)
 					throw new Error(`Unsupported Target AccessHandler`)
-				}
-
-				// Scan with FFProbe:
-				ffProbeProcess = scanWithFFProbe(sourceHandle)
-				const ffProbeScan: FFProbeScanResult = await ffProbeProcess
-				ffProbeProcess = undefined
-				const hasVideoStream =
-					ffProbeScan.streams && ffProbeScan.streams.some((stream) => stream.codec_type === 'video')
-				if (!hasVideoStream) {
-					workInProgress._reportComplete(
-						actualSourceVersionHash,
-						{
-							user: `Preview generation skipped due to file having no video streams`,
-							tech: `Completed at ${Date.now()}`,
-						},
-						undefined
-					)
-					return
 				}
 
 				const args = previewFFMpegArguments(inputPath, true, metadata)

--- a/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/mediaFilePreview.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/expectationHandlers/mediaFilePreview.ts
@@ -28,6 +28,8 @@ import {
 } from './lib'
 import { FFMpegProcess, spawnFFMpeg } from './lib/ffmpeg'
 import { WindowsWorker } from '../windowsWorker'
+import { scanWithFFProbe, FFProbeScanResult } from './lib/scan'
+import { CancelablePromise } from '../../../lib/cancelablePromise'
 
 /**
  * Generates a low-res preview video of a source video file, and stores the resulting file into the target PackageContainer
@@ -178,9 +180,11 @@ export const MediaFilePreview: ExpectationWindowsHandler = {
 				throw new Error(`Target AccessHandler type is wrong`)
 
 			let ffMpegProcess: FFMpegProcess | undefined
+			let ffProbeProcess: CancelablePromise<any> | undefined
 			const workInProgress = new WorkInProgress({ workLabel: 'Generating preview' }, async () => {
 				// On cancel
 				ffMpegProcess?.cancel()
+				ffProbeProcess?.cancel()
 			}).do(async () => {
 				const tryReadPackage = await sourceHandle.checkPackageReadAccess()
 				if (!tryReadPackage.success) throw new Error(tryReadPackage.reason.tech)
@@ -218,6 +222,24 @@ export const MediaFilePreview: ExpectationWindowsHandler = {
 				} else {
 					assertNever(sourceHandle)
 					throw new Error(`Unsupported Target AccessHandler`)
+				}
+
+				// Scan with FFProbe:
+				ffProbeProcess = scanWithFFProbe(sourceHandle)
+				const ffProbeScan: FFProbeScanResult = await ffProbeProcess
+				ffProbeProcess = undefined
+				const hasVideoStream =
+					ffProbeScan.streams && ffProbeScan.streams.some((stream) => stream.codec_type === 'video')
+				if (!hasVideoStream) {
+					workInProgress._reportComplete(
+						actualSourceVersionHash,
+						{
+							user: `Preview generation skipped due to file having no video streams`,
+							tech: `Completed at ${Date.now()}`,
+						},
+						undefined
+					)
+					return
 				}
 
 				const args = previewFFMpegArguments(inputPath, true, metadata)


### PR DESCRIPTION
This PR is being opened on behalf of TV 2 Norge.

This PR generates audio waveform images as thumbnails for audio-only files.

The waveform images currently look like this, with the channels being separated:
![VIGN-BED wav_thumbnail](https://github.com/nrkno/sofie-package-manager/assets/873012/83252790-a2cd-4dd3-88ef-c93455293edb)

FFMPEG documentation on how to generate different-looking waveforms can be found here: https://trac.ffmpeg.org/wiki/Waveform

This has been implemented on the Sofie side as well: https://github.com/nrkno/sofie-core/pull/981
