### PR TITLE
fix: robocopy should not copy timstamps (SOFIE-2986)

### DIFF
--- a/shared/packages/worker/src/worker/workers/windowsWorker/lib/robocopy.ts
+++ b/shared/packages/worker/src/worker/workers/windowsWorker/lib/robocopy.ts
@@ -19,6 +19,7 @@ export function roboCopyFile(src: string, dst: string, progress?: (progress: num
 			'/njs', // Specifies that there is no job summary.
 			// '/mt', // multi-threading
 			// '/z', // Copies files in restartable mode.
+			'/copy:DA', // Copies the data, attributes, but no timestamps. (default is /copy:DAT)
 			srcFolder,
 			dstFolder,
 			srcFileName,


### PR DESCRIPTION

## About Me
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: 
<!-- (pick one) -->
Bug fix


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

The `cleanup` cronjob should clean up files that are older than 30 days.

But if a source file is old it gets cleaned up prematurely, because robocopy copies the timestamps by default.

## New Behavior
<!--
What is the new behavior?
-->

robocopy does not copy the timestamp.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information

Draft, because not tested yet


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
