### PR TITLE
fix: Add option to skip deep scanning of expectations (SOFIE-3060)

### DIFF
--- a/apps/package-manager/packages/generic/src/$schemas/options.json
+++ b/apps/package-manager/packages/generic/src/$schemas/options.json
@@ -31,6 +31,11 @@
 			"type": "boolean",
 			"ui:title": "Use temporary file paths when copying",
 			"default": false
+		},
+		"skipDeepScan": {
+			"type": "boolean",
+			"ui:title": "Skip deep scanning of packages",
+			"default": false
 		}
 	},
 	"required": [],

--- a/apps/package-manager/packages/generic/src/coreHandler.ts
+++ b/apps/package-manager/packages/generic/src/coreHandler.ts
@@ -69,6 +69,7 @@ export class CoreHandler {
 	public delayRemoval = 0
 	public delayRemovalPackageInfo = 0
 	public useTemporaryFilePath = false
+	public skipDeepScan = false
 	public notUsingCore = false
 	public fakeCore: FakeCore
 
@@ -271,6 +272,9 @@ export class CoreHandler {
 			}
 			if (this.deviceSettings['useTemporaryFilePath'] !== this.useTemporaryFilePath) {
 				this.useTemporaryFilePath = this.deviceSettings['useTemporaryFilePath']
+			}
+			if (this.deviceSettings['skipDeepScan'] !== this.skipDeepScan) {
+				this.skipDeepScan = this.deviceSettings['skipDeepScan']
 			}
 
 			if (this._packageManagerHandler) {

--- a/apps/package-manager/packages/generic/src/generateExpectations/nrk/__tests__/nrk.spec.ts
+++ b/apps/package-manager/packages/generic/src/generateExpectations/nrk/__tests__/nrk.spec.ts
@@ -227,10 +227,7 @@ function setup() {
 			_rank: 2,
 		},
 	]
-	const settings: PackageManagerSettings = {
-		delayRemoval: 0,
-		useTemporaryFilePath: false,
-	}
+	const settings: PackageManagerSettings = {}
 	const packageContainers: PackageContainers = {}
 
 	packageContainers[protectString<PackageContainerId>('source0')] = {

--- a/apps/package-manager/packages/generic/src/generateExpectations/nrk/expectations.ts
+++ b/apps/package-manager/packages/generic/src/generateExpectations/nrk/expectations.ts
@@ -240,9 +240,11 @@ function getSideEffectOfExpectation(
 				expectations[scan.id] = scan
 			}
 
-			// All files that have been copied should also be deep-scanned:
-			const deepScan = generatePackageDeepScan(expectation, settings)
-			expectations[deepScan.id] = deepScan
+			if (!settings.skipDeepScan) {
+				// All files that have been copied should also be deep-scanned:
+				const deepScan = generatePackageDeepScan(expectation, settings)
+				expectations[deepScan.id] = deepScan
+			}
 		}
 
 		if (expectation0.sideEffect?.thumbnailContainerId && expectation0.sideEffect?.thumbnailPackageSettings) {
@@ -289,9 +291,11 @@ function getSideEffectOfExpectation(
 			const scan = generatePackageScan(expectation, settings)
 			expectations[scan.id] = scan
 
-			// All files that have been copied should also be deep-scanned:
-			const deepScan = generatePackageDeepScan(expectation, settings)
-			expectations[deepScan.id] = deepScan
+			if (!settings.skipDeepScan) {
+				// All files that have been copied should also be deep-scanned:
+				const deepScan = generatePackageDeepScan(expectation, settings)
+				expectations[deepScan.id] = deepScan
+			}
 		}
 
 		if (expectation0.sideEffect?.thumbnailContainerId && expectation0.sideEffect?.thumbnailPackageSettings) {

--- a/apps/package-manager/packages/generic/src/generated/options.ts
+++ b/apps/package-manager/packages/generic/src/generated/options.ts
@@ -10,4 +10,5 @@ export interface PackageManagerSettings {
 	delayRemoval?: number
 	delayRemovalPackageInfo?: number
 	useTemporaryFilePath?: boolean
+	skipDeepScan?: boolean
 }

--- a/apps/package-manager/packages/generic/src/packageManager.ts
+++ b/apps/package-manager/packages/generic/src/packageManager.ts
@@ -85,10 +85,7 @@ export class PackageManagerHandler {
 	}
 	private _triggerUpdatedExpectedPackagesTimeout: NodeJS.Timeout | null = null
 	public monitoredPackages: Map<PackageContainerId, Map<MonitorId, ExpectedPackageWrap[]>> = new Map()
-	settings: PackageManagerSettings = {
-		delayRemoval: 0,
-		useTemporaryFilePath: false,
-	}
+	settings: PackageManagerSettings = {}
 	callbacksHandler: ExpectationManagerCallbacksHandler
 
 	private dataSnapshot: {
@@ -165,6 +162,7 @@ export class PackageManagerHandler {
 			delayRemoval: this.coreHandler.delayRemoval,
 			delayRemovalPackageInfo: this.coreHandler.delayRemovalPackageInfo,
 			useTemporaryFilePath: this.coreHandler.useTemporaryFilePath,
+			skipDeepScan: this.coreHandler.skipDeepScan,
 		}
 		this.triggerUpdatedExpectedPackages()
 	}


### PR DESCRIPTION
This is useful as a performance improvement in some installations where we don't use/want the deep scanning info anyway

<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About Me

This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a: Minor feature 


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

In one installation, NRK has a special build of PM that has deep scanning disabled, for improved performance.


## New Behavior
<!--
What is the new behavior?
-->

This PR adds an option to the config manifest, to allow for skipping of deep scanning in the Sofie settings GUI.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

* Enable the setting, test that deep scanning is skipped


## Other Information


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
