### PR TITLE
chore: fix: ensure the cache is cleared on error (SOFIE-3061)

### DIFF
--- a/shared/packages/worker/src/worker/accessorHandlers/lib/CachedQuantelGateway.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/lib/CachedQuantelGateway.ts
@@ -61,6 +61,11 @@ export class CachedQuantelGateway extends QuantelGateway {
 		} else {
 			const promise: Promise<any> = getValueFcn()
 
+			// Clear the cache on error:
+			promise.catch(() => {
+				this._cache.delete(cacheKey)
+			})
+
 			this._cache.set(cacheKey, {
 				timestamp: Date.now(),
 				promise: promise,


### PR DESCRIPTION
… time<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About Me

This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: Bug fix 


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

We observed a situation where there where MANY calls to `connect/` at the Quantel Gateway from Package Manager, resulting in overwhelming the quantel gateway and subsequent timeouts.

While I haven't pinpointed the exact root cause of this, this might help in ensuring that we only send one call at a time.


## New Behavior
<!--
What is the new behavior?
-->

Only one call to `connect/` at the Quantel Gateway is sent at a time.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
