### PR TITLE
Fix: closed workers are note cleaned up in availableWorkers & queriedWorkers  (SOFIE-3073)

### DIFF
--- a/shared/packages/expectationManager/src/expectationTracker/lib/trackedExpectationAPI.ts
+++ b/shared/packages/expectationManager/src/expectationTracker/lib/trackedExpectationAPI.ts
@@ -174,6 +174,23 @@ export class TrackedExpectationAPI {
 		if (trackedExp.session.assignedWorker)
 			throw new Error('Internal error: noWorkerAssigned can only be called when assignedWorker is falsy')
 
+		if (trackedExp.availableWorkers.size === 0) {
+			// Special case: No workers are available at all
+			// Return to NEW state, so that new workers can be assigned:
+
+			this.updateTrackedExpectationStatus(trackedExp, {
+				state: ExpectedPackageStatusAPI.WorkStatusState.NEW,
+				reason: {
+					user: 'No workers available',
+					tech: 'availableWorkers=0',
+				},
+				// Don't update the package status, since this means that we don't know anything about the package:
+				dontUpdatePackage: true,
+			})
+
+			return
+		}
+
 		let noAssignedWorkerReason: ExpectedPackageStatusAPI.Reason
 		if (!trackedExp.session.noAssignedWorkerReason) {
 			this.logger.error(

--- a/shared/packages/expectationManager/src/internalManager/lib/trackedWorkerAgents.ts
+++ b/shared/packages/expectationManager/src/internalManager/lib/trackedWorkerAgents.ts
@@ -180,6 +180,20 @@ export class TrackedWorkerAgents {
 			return
 		}
 
+		// Remove any workers that no longer exist:
+		{
+			for (const workerId of trackedExp.availableWorkers.keys()) {
+				if (!this.get(workerId)) {
+					trackedExp.availableWorkers.delete(workerId)
+				}
+			}
+			for (const workerId of trackedExp.queriedWorkers.keys()) {
+				if (!this.get(workerId)) {
+					trackedExp.queriedWorkers.delete(workerId)
+				}
+			}
+		}
+
 		if (!trackedExp.availableWorkers.size) {
 			session.noAssignedWorkerReason = { user: `No workers available`, tech: `No workers available` }
 		}


### PR DESCRIPTION
## About Me

This pull request is posted on behalf of the NRK

## Type of Contribution

This is a:  Bug fix


## Current Behavior


When workers closed down, their ids where left in the trackedExp.availableWorkers, so the only old, invalid workers where queried, and not the new ones. This caused PM to try to spin up new workers indefinitely.

## New Behavior
<!--
What is the new behavior?
-->

Closed down workers are cleaned up from availableWorkers & queriedWorkers.
Also, if availableWorkers is empty, the expectation is moved to the NEW state, so that a new query for available workers is done.




## Other Information


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
