### PR TITLE
feat: add I-frames scan side-effect

### DIFF
--- a/apps/package-manager/packages/generic/src/generateExpectations/nrk/expectations-lib.ts
+++ b/apps/package-manager/packages/generic/src/generateExpectations/nrk/expectations-lib.ts
@@ -354,6 +354,56 @@ export function generatePackageLoudness(
 	})
 }
 
+export function generatePackageIframes(
+	expectation: SomeClipCopyExpectation,
+	settings: PackageManagerSettings
+): Expectation.PackageIframesScan {
+	return {
+		id: protectString<ExpectationId>(expectation.id + '_iframes'),
+		priority: expectation.priority + PriorityAdditions.IFRAMES_SCAN,
+		managerId: expectation.managerId,
+		type: Expectation.Type.PACKAGE_IFRAMES_SCAN,
+		fromPackages: expectation.fromPackages,
+
+		statusReport: {
+			label: `I-frames Scan`,
+			description: `Enumerate I-frames`,
+			displayRank: 15,
+			sendReport: expectation.statusReport.sendReport,
+		},
+
+		startRequirement: {
+			sources: expectation.endRequirement.targets,
+			content: expectation.endRequirement.content,
+			version: expectation.endRequirement.version,
+		},
+		endRequirement: {
+			targets: [
+				{
+					containerId: protectString<PackageContainerId>('__corePackageInfo'),
+					label: 'Core package info',
+					accessors: {
+						[CORE_COLLECTION_ACCESSOR_ID]: {
+							type: Accessor.AccessType.CORE_PACKAGE_INFO,
+						},
+					},
+				},
+			],
+			content: null,
+			version: null,
+		},
+		workOptions: {
+			...expectation.workOptions,
+			allowWaitForCPU: true,
+			requiredForPlayout: false,
+			usesCPUCount: 1,
+			removeDelay: settings.delayRemovalPackageInfo,
+		},
+		dependsOnFulfilled: [expectation.id],
+		triggerByFulfilledIds: [expectation.id],
+	}
+}
+
 export function generateMediaFileThumbnail(
 	expectation: SomeClipFileOnDiskCopyExpectation,
 	packageContainerId: PackageContainerId,

--- a/apps/package-manager/packages/generic/src/generateExpectations/nrk/expectations.ts
+++ b/apps/package-manager/packages/generic/src/generateExpectations/nrk/expectations.ts
@@ -27,6 +27,7 @@ import {
 	generateJsonDataCopy,
 	generatePackageCopyFileProxy,
 	generatePackageLoudness,
+	generatePackageIframes,
 } from './expectations-lib'
 import { getSmartbullExpectedPackages, shouldBeIgnored } from './smartbull'
 import { TEMPORARY_STORAGE_ID } from './lib'
@@ -223,7 +224,7 @@ function getSideEffectOfExpectation(
 		expectation0.type === Expectation.Type.FILE_VERIFY ||
 		expectation0.type === Expectation.Type.FILE_COPY_PROXY
 	) {
-		const expectation = expectation0 as Expectation.FileCopy | Expectation.FileVerify | Expectation.FileCopyProxy
+		const expectation = expectation0
 
 		if (!expectation0.external) {
 			// All files that have been copied should also be scanned:
@@ -282,6 +283,11 @@ function getSideEffectOfExpectation(
 				settings
 			)
 			expectations[loudness.id] = loudness
+		}
+
+		if (expectation0.sideEffect?.iframes) {
+			const iframes = generatePackageIframes(expectation, settings)
+			expectations[iframes.id] = iframes
 		}
 	} else if (expectation0.type === Expectation.Type.QUANTEL_CLIP_COPY) {
 		const expectation = expectation0 as Expectation.QuantelClipCopy
@@ -351,7 +357,7 @@ function getCopyToTemporaryStorage(
 		expectation0.type === Expectation.Type.FILE_VERIFY ||
 		expectation0.type === Expectation.Type.QUANTEL_CLIP_COPY
 	) {
-		const expectation = expectation0 as Expectation.FileCopy | Expectation.FileVerify | Expectation.QuantelClipCopy
+		const expectation = expectation0
 		const proxy: GenerateExpectation | undefined = generatePackageCopyFileProxy(
 			expectation,
 			settings,

--- a/apps/package-manager/packages/generic/src/generateExpectations/nrk/types.ts
+++ b/apps/package-manager/packages/generic/src/generateExpectations/nrk/types.ts
@@ -59,8 +59,8 @@ export enum PriorityAdditions {
 	COPY_PROXY = 90,
 	SCAN = 100,
 	LOUDNESS_SCAN = 500,
+	IFRAMES_SCAN = 501,
 	THUMBNAIL = 1002,
 	PREVIEW = 1003,
 	DEEP_SCAN = 1004,
-	IFRAMES_SCAN = 1005,
 }

--- a/apps/package-manager/packages/generic/src/generateExpectations/nrk/types.ts
+++ b/apps/package-manager/packages/generic/src/generateExpectations/nrk/types.ts
@@ -62,4 +62,5 @@ export enum PriorityAdditions {
 	THUMBNAIL = 1002,
 	PREVIEW = 1003,
 	DEEP_SCAN = 1004,
+	IFRAMES_SCAN = 1005,
 }

--- a/apps/single-app/app/expectedPackages.json
+++ b/apps/single-app/app/expectedPackages.json
@@ -110,7 +110,8 @@
                     ],
                     "inPhaseDifference": true,
                     "balanceDifference": true
-                }
+                },
+				"iframes": true
             }
         },
         {

--- a/shared/packages/api/src/expectationApi.ts
+++ b/shared/packages/api/src/expectationApi.ts
@@ -17,6 +17,7 @@ export namespace Expectation {
 		| PackageScan
 		| PackageDeepScan
 		| PackageLoudnessScan
+		| PackageIframesScan
 		| MediaFileThumbnail
 		| MediaFilePreview
 		| QuantelClipCopy
@@ -38,6 +39,7 @@ export namespace Expectation {
 		PACKAGE_SCAN = 'package_scan',
 		PACKAGE_DEEP_SCAN = 'package_deep_scan',
 		PACKAGE_LOUDNESS_SCAN = 'package_loudness_scan',
+		PACKAGE_IFRAMES_SCAN = 'package_iframes_scan',
 
 		QUANTEL_CLIP_COPY = 'quantel_clip_copy',
 		// QUANTEL_CLIP_SCAN = 'quantel_clip_scan',
@@ -212,6 +214,21 @@ export namespace Expectation {
 				/** Calculate balance difference between stereo channels in the tracks */
 				balanceDifference: boolean
 			}
+		}
+		workOptions: WorkOptions.Base & WorkOptions.RemoveDelay
+	}
+	export interface PackageIframesScan extends Base {
+		type: Type.PACKAGE_IFRAMES_SCAN
+
+		startRequirement: {
+			sources: SpecificPackageContainerOnPackage.FileSource[] | SpecificPackageContainerOnPackage.QuantelClip[]
+			content: FileCopy['endRequirement']['content'] | QuantelClipCopy['endRequirement']['content']
+			version: FileCopy['endRequirement']['version'] | QuantelClipCopy['endRequirement']['version']
+		}
+		endRequirement: {
+			targets: SpecificPackageContainerOnPackage.CorePackage[]
+			content: null // not using content, entries are stored using this.fromPackages
+			version: null
 		}
 		workOptions: WorkOptions.Base & WorkOptions.RemoveDelay
 	}

--- a/shared/packages/api/src/inputApi.ts
+++ b/shared/packages/api/src/inputApi.ts
@@ -92,7 +92,7 @@ export namespace ExpectedPackage {
 			loudnessPackageSettings?: SideEffectLoudnessSettings
 
 			/** Should the package be scanned for I-frames */
-			iframes?: boolean
+			iframes?: SideEffectIframesScanSettings
 
 			/** Other custom configuration */
 			[key: string]: any
@@ -128,6 +128,8 @@ export namespace ExpectedPackage {
 	}
 
 	export type SideEffectLoudnessSettingsChannelSpec = `${number}` | `${number}+${number}`
+
+	export type SideEffectIframesScanSettings = Record<string, never>
 
 	export interface ExpectedPackageMediaFile extends Base {
 		type: PackageType.MEDIA_FILE

--- a/shared/packages/api/src/inputApi.ts
+++ b/shared/packages/api/src/inputApi.ts
@@ -91,6 +91,9 @@ export namespace ExpectedPackage {
 			/** Should the package be scanned for loudness */
 			loudnessPackageSettings?: SideEffectLoudnessSettings
 
+			/** Should the package be scanned for I-frames */
+			iframes?: boolean
+
 			/** Other custom configuration */
 			[key: string]: any
 		}

--- a/shared/packages/worker/package.json
+++ b/shared/packages/worker/package.json
@@ -29,6 +29,7 @@
         "@sofie-package-manager/api": "1.50.5",
         "abort-controller": "^3.0.0",
         "atem-connection": "^3.2.0",
+        "csv-parser": "^3.0.0",
         "deep-diff": "^1.0.2",
         "form-data": "^4.0.0",
         "node-fetch": "^2.6.1",

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/lib/coreApi.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/lib/coreApi.ts
@@ -80,9 +80,13 @@ export type LoudnessScanResultForStream =
 	  }
 
 export enum CompressionType {
+	/** Undetected */
 	Unknown = 'unknown',
-	Intra = 'intra',
+	/** Every frame is a I-frame */
+	AllIntra = 'all_intra',
+	/** All I-frame are spaced evenly */
 	FixedDistance = 'fixed_distance',
+	/** I-frame distances vary */
 	VariableDistance = 'variable_distance',
 }
 
@@ -91,7 +95,7 @@ export type IframesScanResult =
 			type: CompressionType.Unknown
 	  }
 	| {
-			type: CompressionType.Intra
+			type: CompressionType.AllIntra
 	  }
 	| {
 			type: CompressionType.FixedDistance

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/lib/coreApi.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/lib/coreApi.ts
@@ -2,6 +2,7 @@ export enum PackageInfoType {
 	Scan = 'scan',
 	DeepScan = 'deepScan',
 	Loudness = 'loudness',
+	Iframes = 'iframes',
 
 	/** Unknown JSON data */
 	JSON = 'json',
@@ -76,4 +77,29 @@ export type LoudnessScanResultForStream =
 			 * This will only be calculated if "layout" is "stereo"
 			 * */
 			balanceDifference?: number
+	  }
+
+export enum CompressionType {
+	Unknown = 'unknown',
+	Intra = 'intra',
+	FixedDistance = 'fixed_distance',
+	VariableDistance = 'variable_distance',
+}
+
+export type IframesScanResult =
+	| {
+			type: CompressionType.Unknown
+	  }
+	| {
+			type: CompressionType.Intra
+	  }
+	| {
+			type: CompressionType.FixedDistance
+			/** Distance between I-frames, expressed in seconds */
+			distance: number
+	  }
+	| {
+			type: CompressionType.VariableDistance
+			/** Frame times of I-frames in seconds */
+			iframeTimes: number[]
 	  }

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/lib/scan.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/lib/scan.ts
@@ -717,9 +717,9 @@ export function scanIframes(
 		})
 
 		const iframes: number[] = []
-		let distance: number | undefined
+		let prevDistance: number | undefined
 		let prevIframePtsTime: number | undefined
-		let frameDuration: number | undefined
+		let prevFrameDuration: number | undefined
 		let distanceVaries = false
 		let maxDistance = 0
 
@@ -750,15 +750,15 @@ export function scanIframes(
 					iframes.push(ptsTime)
 					onProgress(ptsTime / duration)
 					if (prevIframePtsTime !== undefined) {
-						const newDistance = ptsTime - prevIframePtsTime
-						if (distance && Math.abs(newDistance - distance) > EPSILON) {
+						const distance = ptsTime - prevIframePtsTime
+						if (prevDistance && Math.abs(distance - prevDistance) > EPSILON) {
 							distanceVaries = true
 						}
-						maxDistance = Math.max(maxDistance, newDistance)
-						distance = newDistance
+						maxDistance = Math.max(maxDistance, distance)
+						prevDistance = distance
 					}
 					prevIframePtsTime = ptsTime
-					frameDuration = durationTime
+					prevFrameDuration = durationTime
 				}
 			})
 			.on('error', onError)
@@ -769,14 +769,14 @@ export function scanIframes(
 				ffMpegProcess = undefined
 				if (code === 0) {
 					// success
-					if (frameDuration && Math.abs(maxDistance / frameDuration - 1) < EPSILON) {
+					if (prevFrameDuration && Math.abs(maxDistance / prevFrameDuration - 1) < EPSILON) {
 						resolve({
 							type: CompressionType.Intra,
 						})
-					} else if (!distanceVaries && distance) {
+					} else if (!distanceVaries && prevDistance) {
 						resolve({
 							type: CompressionType.FixedDistance,
-							distance: distance,
+							distance: prevDistance,
 						})
 					} else if (iframes.length) {
 						resolve({

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/lib/scan.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/lib/scan.ts
@@ -718,6 +718,7 @@ export function scanIframes(
 
 		const iframes: number[] = []
 		let prevDistance: number | undefined
+		let firstIframePtsTime: number | undefined
 		let prevIframePtsTime: number | undefined
 		let prevFrameDuration: number | undefined
 		let distanceVaries = false
@@ -748,6 +749,10 @@ export function scanIframes(
 				if (dataType === 'frame' && pictType === 'I') {
 					const ptsTime = parseFloat(data[1])
 					const durationTime = parseFloat(data[2])
+
+					if (firstIframePtsTime === undefined) {
+						firstIframePtsTime = ptsTime
+					}
 					iframes.push(ptsTime)
 					onProgress(ptsTime / duration)
 					if (prevIframePtsTime !== undefined) {
@@ -775,12 +780,12 @@ export function scanIframes(
 					// success
 					if (prevFrameDuration && Math.abs(maxDistance / prevFrameDuration - 1) < EPSILON) {
 						resolve({
-							type: CompressionType.Intra,
+							type: CompressionType.AllIntra,
 						})
-					} else if (!distanceVaries && prevDistance) {
+					} else if (!distanceVaries && prevIframePtsTime !== undefined && firstIframePtsTime !== undefined) {
 						resolve({
 							type: CompressionType.FixedDistance,
-							distance: prevDistance,
+							distance: (prevIframePtsTime - firstIframePtsTime) / iframes.length,
 						})
 					} else if (distanceVaries && iframes.length) {
 						resolve({

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/lib/scan.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/lib/scan.ts
@@ -743,8 +743,9 @@ export function scanIframes(
 			.pipe(csvParser({ headers: false }))
 			.on('data', (data) => {
 				if (cancelled) return
+				const dataType = data[0]
 				const pictType = data[3]
-				if (pictType === 'I') {
+				if (dataType === 'frame' && pictType === 'I') {
 					const ptsTime = parseFloat(data[1])
 					const durationTime = parseFloat(data[2])
 					iframes.push(ptsTime)
@@ -759,6 +760,9 @@ export function scanIframes(
 					}
 					prevIframePtsTime = ptsTime
 					prevFrameDuration = durationTime
+				} else if (dataType === 'frame' && pictType === 'P') {
+					const ptsTime = parseFloat(data[1])
+					onProgress(ptsTime / duration)
 				}
 			})
 			.on('error', onError)
@@ -778,7 +782,7 @@ export function scanIframes(
 							type: CompressionType.FixedDistance,
 							distance: prevDistance,
 						})
-					} else if (iframes.length) {
+					} else if (distanceVaries && iframes.length) {
 						resolve({
 							type: CompressionType.VariableDistance,
 							iframeTimes: iframes,

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/packageIframesScan.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/packageIframesScan.ts
@@ -1,0 +1,302 @@
+import { getStandardCost } from '../lib/lib'
+import { BaseWorker } from '../../../worker'
+import {
+	Accessor,
+	hashObj,
+	Expectation,
+	ReturnTypeDoYouSupportExpectation,
+	ReturnTypeGetCostFortExpectation,
+	ReturnTypeIsExpectationFulfilled,
+	ReturnTypeIsExpectationReadyToStartWorkingOn,
+	ReturnTypeRemoveExpectation,
+	stringifyError,
+	startTimer,
+} from '@sofie-package-manager/api'
+import { isCorePackageInfoAccessorHandle } from '../../../accessorHandlers/accessor'
+import { IWorkInProgress, WorkInProgress } from '../../../lib/workInProgress'
+import { checkWorkerHasAccessToPackageContainersOnPackage, lookupAccessorHandles, LookupPackageContainer } from './lib'
+import { CancelablePromise } from '../../../lib/cancelablePromise'
+import {
+	FFProbeScanResult,
+	isAnFFMpegSupportedSourceAccessor,
+	isAnFFMpegSupportedSourceAccessorHandle,
+	scanIframes,
+	scanWithFFProbe,
+} from './lib/scan'
+import { ExpectationHandlerGenericWorker, GenericWorker } from '../genericWorker'
+import { CompressionType, IframesScanResult, PackageInfoType } from './lib/coreApi'
+
+/**
+ * Performs an I-frames scan of the source package
+ */
+export const PackageIframesScan: ExpectationHandlerGenericWorker = {
+	doYouSupportExpectation(exp: Expectation.Any, worker: GenericWorker): ReturnTypeDoYouSupportExpectation {
+		if (worker.testFFMpeg)
+			return {
+				support: false,
+				reason: {
+					user: 'There is an issue with the Worker (FFMpeg)',
+					tech: `Cannot access FFMpeg executable: ${worker.testFFMpeg}`,
+				},
+			}
+		if (worker.testFFProbe)
+			return {
+				support: false,
+				reason: {
+					user: 'There is an issue with the Worker (FFProbe)',
+					tech: `Cannot access FFProbe executable: ${worker.testFFProbe}`,
+				},
+			}
+		return checkWorkerHasAccessToPackageContainersOnPackage(worker, {
+			sources: exp.startRequirement.sources,
+		})
+	},
+	getCostForExpectation: async (
+		exp: Expectation.Any,
+		worker: BaseWorker
+	): Promise<ReturnTypeGetCostFortExpectation> => {
+		if (!isPackageIframesScan(exp)) throw new Error(`Wrong exp.type: "${exp.type}"`)
+		return getStandardCost(exp, worker)
+	},
+
+	isExpectationReadyToStartWorkingOn: async (
+		exp: Expectation.Any,
+		worker: BaseWorker
+	): Promise<ReturnTypeIsExpectationReadyToStartWorkingOn> => {
+		if (!isPackageIframesScan(exp)) throw new Error(`Wrong exp.type: "${exp.type}"`)
+
+		const lookupSource = await lookupIframesSources(worker, exp)
+		if (!lookupSource.ready) return { ready: lookupSource.ready, sourceExists: false, reason: lookupSource.reason }
+		const lookupTarget = await lookupIframesTargets(worker, exp)
+		if (!lookupTarget.ready) return { ready: lookupTarget.ready, reason: lookupTarget.reason }
+
+		const tryReading = await lookupSource.handle.tryPackageRead()
+		if (!tryReading.success)
+			return { ready: false, sourceExists: tryReading.packageExists, reason: tryReading.reason }
+
+		return {
+			ready: true,
+		}
+	},
+	isExpectationFulfilled: async (
+		exp: Expectation.Any,
+		wasFulfilled: boolean,
+		worker: BaseWorker
+	): Promise<ReturnTypeIsExpectationFulfilled> => {
+		if (!isPackageIframesScan(exp)) throw new Error(`Wrong exp.type: "${exp.type}"`)
+
+		const lookupSource = await lookupIframesSources(worker, exp)
+		if (!lookupSource.ready)
+			return {
+				fulfilled: false,
+				reason: {
+					user: `Not able to access source, due to ${lookupSource.reason.user}`,
+					tech: `Not able to access source: ${lookupSource.reason.tech}`,
+				},
+			}
+		const lookupTarget = await lookupIframesTargets(worker, exp)
+		if (!lookupTarget.ready)
+			return {
+				fulfilled: false,
+				reason: {
+					user: `Not able to access target, due to ${lookupTarget.reason.user}`,
+					tech: `Not able to access target: ${lookupTarget.reason.tech}`,
+				},
+			}
+
+		const actualSourceVersion = await lookupSource.handle.getPackageActualVersion()
+
+		if (!isCorePackageInfoAccessorHandle(lookupTarget.handle)) throw new Error(`Target AccessHandler type is wrong`)
+
+		const packageInfoSynced = await lookupTarget.handle.findUnUpdatedPackageInfo(
+			PackageInfoType.Iframes,
+			exp,
+			exp.startRequirement.content,
+			actualSourceVersion,
+			exp.endRequirement.version
+		)
+		if (packageInfoSynced.needsUpdate) {
+			if (wasFulfilled) {
+				// Remove the outdated scan result:
+				await lookupTarget.handle.removePackageInfo(PackageInfoType.Iframes, exp)
+			}
+			return { fulfilled: false, reason: packageInfoSynced.reason }
+		} else {
+			return { fulfilled: true }
+		}
+	},
+	workOnExpectation: async (exp: Expectation.Any, worker: BaseWorker): Promise<IWorkInProgress> => {
+		if (!isPackageIframesScan(exp)) throw new Error(`Wrong exp.type: "${exp.type}"`)
+		// Scan the source media file and upload the results to Core
+		const timer = startTimer()
+
+		const lookupSource = await lookupIframesSources(worker, exp)
+		if (!lookupSource.ready) throw new Error(`Can't start working due to source: ${lookupSource.reason.tech}`)
+
+		const lookupTarget = await lookupIframesTargets(worker, exp)
+		if (!lookupTarget.ready) throw new Error(`Can't start working due to target: ${lookupTarget.reason.tech}`)
+
+		let currentProcess: CancelablePromise<any> | undefined
+		const workInProgress = new WorkInProgress({ workLabel: 'Scanning file (I-frames)' }, async () => {
+			// On cancel
+			currentProcess?.cancel()
+		}).do(async () => {
+			const sourceHandle = lookupSource.handle
+			const targetHandle = lookupTarget.handle
+			if (
+				!isAnFFMpegSupportedSourceAccessor(lookupSource.accessor) ||
+				lookupTarget.accessor.type !== Accessor.AccessType.CORE_PACKAGE_INFO
+			)
+				throw new Error(
+					`PackageIframesScan.workOnExpectation: Unsupported accessor source-target pair "${lookupSource.accessor.type}"-"${lookupTarget.accessor.type}"`
+				)
+
+			if (!isAnFFMpegSupportedSourceAccessorHandle(sourceHandle))
+				throw new Error(`Source AccessHandler type is wrong`)
+
+			if (!isCorePackageInfoAccessorHandle(targetHandle)) throw new Error(`Target AccessHandler type is wrong`)
+
+			const tryReadPackage = await sourceHandle.checkPackageReadAccess()
+			if (!tryReadPackage.success) throw new Error(tryReadPackage.reason.tech)
+
+			const actualSourceVersion = await sourceHandle.getPackageActualVersion()
+			const sourceVersionHash = hashObj(actualSourceVersion)
+
+			workInProgress._reportProgress(sourceVersionHash, 0.01)
+
+			// Scan with FFProbe:
+			currentProcess = scanWithFFProbe(sourceHandle)
+			const ffProbeScan: FFProbeScanResult = await currentProcess
+			const hasVideoStream =
+				ffProbeScan.streams && ffProbeScan.streams.some((stream) => stream.codec_type === 'video')
+			workInProgress._reportProgress(sourceVersionHash, 0.1)
+			currentProcess = undefined
+
+			let result: IframesScanResult = { type: CompressionType.Unknown }
+			if (hasVideoStream) {
+				currentProcess = new CancelablePromise<IframesScanResult>(async (resolve, reject, onCancel) => {
+					let ignoreNextCancelError = false
+
+					const scanMoreInfoProcess = scanIframes(
+						sourceHandle,
+						null,
+						(progress) => {
+							workInProgress._reportProgress(sourceVersionHash, 0.21 + 0.77 * progress)
+						},
+						worker.logger.category('scanMoreInfo'),
+						Number(ffProbeScan.format?.duration) || 10000
+					)
+					onCancel(() => {
+						scanMoreInfoProcess.cancel()
+					})
+
+					scanMoreInfoProcess.then(
+						(result) => {
+							resolve(result)
+						},
+						(error) => {
+							if (`${error}`.match(/cancelled/i) && ignoreNextCancelError) {
+								// ignore this
+								ignoreNextCancelError = false
+							} else {
+								reject(error)
+							}
+						}
+					)
+				})
+
+				result = await currentProcess
+				currentProcess = undefined
+			}
+			workInProgress._reportProgress(sourceVersionHash, 0.99)
+
+			// all done:
+			const scanOperation = await targetHandle.prepareForOperation('Deep scan', sourceHandle)
+			await targetHandle.updatePackageInfo(
+				PackageInfoType.Iframes,
+				exp,
+				exp.startRequirement.content,
+				actualSourceVersion,
+				exp.endRequirement.version,
+				result
+			)
+
+			await targetHandle.finalizePackage(scanOperation)
+
+			const duration = timer.get()
+			workInProgress._reportComplete(
+				sourceVersionHash,
+				{
+					user: `Scan completed in ${Math.round(duration / 100) / 10}s`,
+					tech: `Completed at ${Date.now()}`,
+				},
+				undefined
+			)
+		})
+
+		return workInProgress
+	},
+	removeExpectation: async (exp: Expectation.Any, worker: BaseWorker): Promise<ReturnTypeRemoveExpectation> => {
+		if (!isPackageIframesScan(exp)) throw new Error(`Wrong exp.type: "${exp.type}"`)
+		const lookupTarget = await lookupIframesTargets(worker, exp)
+		if (!lookupTarget.ready)
+			return {
+				removed: false,
+				reason: {
+					user: `Can't access target, due to: ${lookupTarget.reason.user}`,
+					tech: `No access to target: ${lookupTarget.reason.tech}`,
+				},
+			}
+		if (!isCorePackageInfoAccessorHandle(lookupTarget.handle)) throw new Error(`Target AccessHandler type is wrong`)
+
+		try {
+			await lookupTarget.handle.removePackageInfo(PackageInfoType.Iframes, exp)
+		} catch (err) {
+			return {
+				removed: false,
+				reason: {
+					user: `Cannot remove the scan result due to an internal error`,
+					tech: `Cannot remove CorePackageInfo: ${stringifyError(err)}`,
+				},
+			}
+		}
+
+		return { removed: true }
+	},
+}
+function isPackageIframesScan(exp: Expectation.Any): exp is Expectation.PackageIframesScan {
+	return exp.type === Expectation.Type.PACKAGE_IFRAMES_SCAN
+}
+type Metadata = any // not used
+
+async function lookupIframesSources(
+	worker: BaseWorker,
+	exp: Expectation.PackageIframesScan
+): Promise<LookupPackageContainer<Metadata>> {
+	return lookupAccessorHandles<Metadata>(
+		worker,
+		exp.startRequirement.sources,
+		exp.startRequirement.content,
+		exp.workOptions,
+		{
+			read: true,
+			readPackage: true,
+			packageVersion: exp.startRequirement.version,
+		}
+	)
+}
+async function lookupIframesTargets(
+	worker: BaseWorker,
+	exp: Expectation.PackageIframesScan
+): Promise<LookupPackageContainer<Metadata>> {
+	return lookupAccessorHandles<Metadata>(
+		worker,
+		exp.endRequirement.targets,
+		exp.endRequirement.content,
+		exp.workOptions,
+		{
+			write: true,
+			writePackageContainer: true,
+		}
+	)
+}

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/packageIframesScan.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/packageIframesScan.ts
@@ -177,20 +177,20 @@ export const PackageIframesScan: ExpectationHandlerGenericWorker = {
 				currentProcess = new CancelablePromise<IframesScanResult>(async (resolve, reject, onCancel) => {
 					let ignoreNextCancelError = false
 
-					const scanMoreInfoProcess = scanIframes(
+					const scanIframesProcess = scanIframes(
 						sourceHandle,
 						null,
 						(progress) => {
 							workInProgress._reportProgress(sourceVersionHash, 0.21 + 0.77 * progress)
 						},
-						worker.logger.category('scanMoreInfo'),
+						worker.logger.category('scanIframes'),
 						Number(ffProbeScan.format?.duration) || 10000
 					)
 					onCancel(() => {
-						scanMoreInfoProcess.cancel()
+						scanIframesProcess.cancel()
 					})
 
-					scanMoreInfoProcess.then(
+					scanIframesProcess.then(
 						(result) => {
 							resolve(result)
 						},
@@ -211,7 +211,7 @@ export const PackageIframesScan: ExpectationHandlerGenericWorker = {
 			workInProgress._reportProgress(sourceVersionHash, 0.99)
 
 			// all done:
-			const scanOperation = await targetHandle.prepareForOperation('Deep scan', sourceHandle)
+			const scanOperation = await targetHandle.prepareForOperation('Iframe scan', sourceHandle)
 			await targetHandle.updatePackageInfo(
 				PackageInfoType.Iframes,
 				exp,

--- a/shared/packages/worker/src/worker/workers/genericWorker/genericWorker.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/genericWorker.ts
@@ -31,6 +31,7 @@ import { testFFMpeg, testFFProbe } from './expectationHandlers/lib/ffmpeg'
 import { JsonDataCopy } from './expectationHandlers/jsonDataCopy'
 import { SetupPackageContainerMonitorsResult } from '../../accessorHandlers/genericHandle'
 import { FileVerify } from './expectationHandlers/fileVerify'
+import { PackageIframesScan } from './expectationHandlers/packageIframesScan'
 
 export type ExpectationHandlerGenericWorker = ExpectationHandler<GenericWorker>
 
@@ -110,6 +111,8 @@ export class GenericWorker extends BaseWorker {
 				return PackageDeepScan
 			case Expectation.Type.PACKAGE_LOUDNESS_SCAN:
 				return PackageLoudnessScan
+			case Expectation.Type.PACKAGE_IFRAMES_SCAN:
+				return PackageIframesScan
 			case Expectation.Type.MEDIA_FILE_THUMBNAIL:
 				return MediaFileThumbnail
 			case Expectation.Type.MEDIA_FILE_PREVIEW:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2025,6 +2025,7 @@ __metadata:
     "@types/tmp": "npm:~0.2.2"
     abort-controller: "npm:^3.0.0"
     atem-connection: "npm:^3.2.0"
+    csv-parser: "npm:^3.0.0"
     deep-diff: "npm:^1.0.2"
     form-data: "npm:^4.0.0"
     jest: "npm:*"
@@ -4375,6 +4376,17 @@ __metadata:
   bin:
     cssesc: bin/cssesc
   checksum: 10/0e161912c1306861d8f46e1883be1cbc8b1b2879f0f509287c0db71796e4ddfb97ac96bdfca38f77f452e2c10554e1bb5678c99b07a5cf947a12778f73e47e12
+  languageName: node
+  linkType: hard
+
+"csv-parser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "csv-parser@npm:3.0.0"
+  dependencies:
+    minimist: "npm:^1.2.0"
+  bin:
+    csv-parser: bin/csv-parser
+  checksum: 10/2f003d15d8361a94359d6715a8f05feac1252ab4d1d4e2908ea1baa0454c7e00fb99c53cdc86336635c5fd04f17b510291338df93da1e54944695f0c3b4a6bc1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About Me
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of TV 2 Norge.

## Type of Contribution

This is a: 
<!-- (pick one) -->
Feature


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
There is no way to tell whether a video package is intra-frame compressed or where the I-frames are.

## New Behavior
<!--
What is the new behavior?
-->
By specifying `iframes: true` in `sideEffects`, I-frames scan can be enabled for video packages. The scan result provides information about the compression: whether it's intra-frame, fixed I-frame distance (and what the distance is), or if it's variable-distance (and where the I-frames are).

This can be useful when working with video players that can't seek to any arbitrary frame, only to I-frames.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->
It can be tested using the single-app in local-only mode, using packages from expectedPackages.json. At least three sample files are needed: intra-frame, with constant I-frame distance, and with variable I-frame distance (can be produced by most video editing software by enabling I-frames on scene changes). When scanned, the result should adhere to one of the three _known_ interfaces in the IframesScanResult union.

## Other Information


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
