### PR TITLE
fix: change default `minRunningApps` to 1

### DIFF
--- a/shared/packages/api/src/config.ts
+++ b/shared/packages/api/src/config.ts
@@ -205,7 +205,7 @@ const appContainerArguments = defineArguments({
 	},
 	minRunningApps: {
 		type: 'number',
-		default: parseInt(process.env.APP_CONTAINER_MIN_RUNNING_APPS || '', 10) || 0,
+		default: parseInt(process.env.APP_CONTAINER_MIN_RUNNING_APPS || '', 10) || 1,
 		describe: 'Minimum amount of apps (of a certain appType) to be running',
 	},
 	maxAppKeepalive: {


### PR DESCRIPTION


## About Me
This pull request is posted on behalf of the BBC


## Type of Contribution

This is a: Bug fix 

## Current Behavior
When the system is idle, package-manager is restarting the workers on a 10 minute interval.

This is happening because the workers are idle, so trigger the `spinDownTime` timer. As `minRunningApps` is 0, the appContainer would approve the request and spin down the worker.

Shortly after, the workforce would update its status and report itself as BAD due to `No workers connected to workforce`, causing an error to be reported in Sofie.

Then a little later, `requestAppTypeForExpectation` is called from `checkIfNeedToScaleUp` which results in a new worker starting and the error being dismissed. 

## New Behavior
The `minRunningApps` now defaults to 1, so that the system doesn't get itself into this restart loop.



## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
