### PR TITLE
feat(worker): when appContainerURL is not specified, run standalone, for external management

### DIFF
--- a/shared/packages/worker/src/dummyAppContainerApi.ts
+++ b/shared/packages/worker/src/dummyAppContainerApi.ts
@@ -1,0 +1,81 @@
+import {
+	AdapterClient,
+	LoggerInstance,
+	AppContainerWorkerAgent,
+	WorkerAgentId,
+	DataId,
+	LockId,
+	protectString,
+	ClientConnectionOptions,
+	Hook,
+} from '@sofie-package-manager/api'
+
+/**
+ * Exposes the API-methods of a Workforce, to be called from the WorkerAgent
+ * Note: The WorkerAgent connects to the Workforce, therefore the WorkerAgent is the AdapterClient here.
+ * The corresponding other side is implemented at shared/packages/workforce/src/workerAgentApi.ts
+ */
+export class DummyAppContainerAPI
+	extends AdapterClient<AppContainerWorkerAgent.WorkerAgent, AppContainerWorkerAgent.AppContainer>
+	implements AppContainerWorkerAgent.AppContainer
+{
+	private workerStorage: Map<DataId, any> = new Map()
+
+	constructor(public id: WorkerAgentId, logger: LoggerInstance) {
+		super(logger, id, 'N/A')
+		this.on('error', () => {
+			// an empty error handler to avoid HelpfulEventEmitter complaining
+			return
+		})
+	}
+	protected _sendMessage = async (
+		_type: keyof AppContainerWorkerAgent.AppContainer,
+		..._args: any[]
+	): Promise<any> => {
+		return
+	}
+	async init(
+		connectionOptions: ClientConnectionOptions | NoClientConnectionOptions,
+		_clientMethods: Omit<AppContainerWorkerAgent.WorkerAgent, 'id'>
+	): Promise<void> {
+		if (connectionOptions.type !== 'none') throw new Error('Invalid connection type for DummyAppContainerAPI')
+	}
+	hook(_serverHook: Hook<AppContainerWorkerAgent.AppContainer, AppContainerWorkerAgent.WorkerAgent>): void {
+		return
+	}
+	terminate(): void {
+		return
+	}
+	debugCutConnection(): void {
+		return
+	}
+	get connected(): boolean {
+		return true
+	}
+	protected addHelpfulEventCheck(_event: string): void {
+		return
+	}
+	async ping(): Promise<void> {
+		return
+	}
+	async requestSpinDown(): Promise<void> {
+		return
+	}
+	async workerStorageWriteLock(dataId: DataId): Promise<{ lockId: LockId; current: any }> {
+		return { lockId: protectString('dummy'), current: this.workerStorage.get(dataId) }
+	}
+	async workerStorageReleaseLock(): Promise<void> {
+		return
+	}
+	async workerStorageWrite(dataId: DataId, _lockId: LockId, data: string): Promise<void> {
+		this.workerStorage.set(dataId, data)
+		return
+	}
+	async workerStorageRead(dataId: DataId): Promise<any> {
+		return this.workerStorage.get(dataId)
+	}
+}
+
+export type NoClientConnectionOptions = {
+	type: 'none'
+}

--- a/tests/internal-tests/src/__tests__/lib/setupEnv.ts
+++ b/tests/internal-tests/src/__tests__/lib/setupEnv.ts
@@ -76,7 +76,7 @@ export const defaultTestConfig: SingleAppConfig = {
 	worker: {
 		workerId: protectString<WorkerAgentId>('worker'),
 		workforceURL: null,
-		appContainerURL: null,
+		appContainerURL: 'internal', // This needs to be "internal", because `null` means run standalone
 		resourceId: '',
 		networkIds: [],
 		windowsDriveLetters: ['X', 'Y', 'Z'],
@@ -274,8 +274,7 @@ export async function prepareTestEnvironment(debugLogging: boolean): Promise<Tes
 				packageId: ExpectedPackageId,
 				packageStatus: Omit<ExpectedPackageStatusAPI.PackageContainerPackageStatus, 'statusChanged'> | null
 			) => {
-				if (debugLogging)
-					console.log('reportPackageContainerPackageStatus', containerId, packageId, packageStatus)
+				if (debugLogging) console.log('reportPackageContainerPackageStatus', containerId, packageId, packageStatus)
 
 				let container = containerStatuses[containerId]
 				if (!container) {


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About Me
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: 
<!-- (pick one) -->
Feature


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->


## New Behavior
<!--
What is the new behavior?
-->
It is possible to run the worker process without an appContainerURL specified, in which case it will operate in standalone mode. This is the new default, when running the worker process independently. The workers will have `appContainerURL` provided when started by the App Container (so called "single-app" mode).


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->
* Run the worker process independently and see if it doesn't shut down automatically
* Run the single-process package manager and see if it operates as before.


## Other Information


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
